### PR TITLE
MAINT-26769 : AppCenter: Bug-Fix: Make sure that the update of the default app is made instantly.

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/AdminSetup.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/AdminSetup.vue
@@ -22,7 +22,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           class="appAdminTabs"
           background-color="transparent"
         >
-          <v-tab>
+          <v-tab @click="loadApplicationsList">
             {{ $t('appCenter.adminSetupForm.applications') }}
           </v-tab>
           <v-tab>
@@ -30,7 +30,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           </v-tab>
 
           <v-tab-item class="px-4 py-2">
-            <adminSetup-list />
+            <adminSetup-list :key="adminSetupListKey" />
           </v-tab-item>
           <v-tab-item class="px-4 py-2">
             <adminSetup-generalParams />
@@ -40,3 +40,18 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </v-row>
   </v-app>
 </template>
+
+<script>
+export default {
+  data() {
+    return {
+      adminSetupListKey: 0,
+    };
+  },
+  methods: {
+    loadApplicationsList() {
+      this.adminSetupListKey++;
+    }
+  },
+};
+</script>


### PR DESCRIPTION
When updating the default app image and then going back to the applications list tab, the applications which has default image are displayed with the old one, in order to display them with the new image instantly i made sure to refresh the applications tab each time it is clicked.