### PR TITLE
MAINT-26556: Make sur to display the image name and the remove button after uploading a new default application image.

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/AdminSetupGeneralParams.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/AdminSetupGeneralParams.vue
@@ -129,7 +129,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 @change="handleDefaultAppImageFileUpload()"
               >
             </div>
-            <div v-show="!defaultAppImageViewMode && defaultAppImage.fileName && defaultAppImage.fileBody">
+            <div v-show="!defaultAppImageViewMode && defaultAppImage.fileName">
               <span>
                 {{ defaultAppImage.fileName }}
               </span>


### PR DESCRIPTION
Make sure to check only on file name if exists, in order to display the image name and the remove file button.