### PR TITLE
Make sure that when a system application is updated it is not deleted after system restart.

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/AdminSetupList.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/AdminSetupList.vue
@@ -64,7 +64,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               v-exo-tooltip.bottom.body="props.item.title.length > 22 ? props.item.title : ''"
               class="text-md-center tableAppTitle"
             >
-              {{ props.item.title }}
+              {{ props.item.displayName }}
             </td>
             <td 
               v-exo-tooltip.bottom.body="props.item.url.length > 23 ? props.item.url : ''"
@@ -289,7 +289,7 @@ export default {
             if (app.system) {
               const appTitle = /\s/.test(app.title) ? app.title.replace(/ /g,'.').toLowerCase() : app.title.toLowerCase();
               if (!this.$t(`appCenter.system.application.${appTitle}`).startsWith('appCenter.system.application')) {
-                data.applications[this.getAppIndex(data.applications, app.id)].title = this.$t(`appCenter.system.application.${appTitle}`);   
+                data.applications[this.getAppIndex(data.applications, app.id)].displayName = this.$t(`appCenter.system.application.${appTitle}`);
               }
             }
 


### PR DESCRIPTION
A system application's title and url are mandatory and must not be updated they are a unique peer. The the internationalization of system applications the title is set explicitly to the translated value and when updating a system application the title is updated too which causes on the next start of its delete and probably re-injection which causes the loss of the changes. In order to avoid the explicit update of the system applications title i added a new attribute the "displayName".