### PR TITLE
MAINT-27752: Make sure that applications images are displayed for admins.

### DIFF
--- a/app-center-services/src/main/java/org/exoplatform/appcenter/service/ApplicationCenterService.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/service/ApplicationCenterService.java
@@ -639,8 +639,11 @@ public class ApplicationCenterService implements Startable {
     if (application == null) {
       throw new ApplicationNotFoundException("Application with id " + applicationId + " wasn't found");
     }
-    if (!hasPermission(username, application)) {
-      throw new IllegalAccessException("User " + username + " isn't allowed to access application with id " + applicationId);
+    // if user is admin then no need to check for permissions
+    if (!isAdmin(username)) {
+      if (!hasPermission(username, application)) {
+        throw new IllegalAccessException("User " + username + " isn't allowed to access application with id " + applicationId);
+      }
     }
     if (application.getImageFileId() != null && application.getImageFileId() > 0) {
       return appCenterStorage.getApplicationImageLastUpdated(application.getImageFileId());


### PR DESCRIPTION
The issue is that the service that returns applications images checks on permissions. I made sure that administrators have always the permissions ti views applications images.