### PR TITLE
Improve image display if binary content is not available

### DIFF
--- a/app-center-services/src/main/java/org/exoplatform/appcenter/service/ApplicationCenterService.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/service/ApplicationCenterService.java
@@ -667,15 +667,19 @@ public class ApplicationCenterService implements Startable {
         throw new IllegalAccessException("User " + username + " isn't allowed to access application with id " + applicationId);
       }
     }
+    InputStream applicationImageInputStream=null;
     if (application.getImageFileId() != null && application.getImageFileId() > 0) {
-      return appCenterStorage.getApplicationImageInputStream(application.getImageFileId());
-    } else {
+      applicationImageInputStream = appCenterStorage.getApplicationImageInputStream(application.getImageFileId());
+    }
+    if (applicationImageInputStream==null) {
+      //result is null if there is no image associated to the application
+      //or if the image is not readable (data corruption, or quarantined by an antivirus)
       Long defaultImageId = getDefaultImageId();
       if (defaultImageId != null && defaultImageId > 0) {
-        return appCenterStorage.getApplicationImageInputStream(defaultImageId);
+        applicationImageInputStream=appCenterStorage.getApplicationImageInputStream(defaultImageId);
       }
     }
-    return null;
+    return applicationImageInputStream;
   }
 
   /**


### PR DESCRIPTION
Prior to this change, when a binary content is not accessible, there is no error log related, and the application image is displayed as broken
The binary content can be not accessible because of data corruption, or because it was quarantined by an antivirus.
This change will allow to display the default application image if the current one is not accessible