### PR TITLE
MAINT-28760 : search applications in the app-center is case sensitive when the app url contains uppercase letters

### DIFF
--- a/app-center-services/src/main/java/org/exoplatform/appcenter/dao/ApplicationDAO.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/dao/ApplicationDAO.java
@@ -44,6 +44,7 @@ public class ApplicationDAO extends GenericDAOJPAImpl<ApplicationEntity, Long> {
       query = getEntityManager().createNamedQuery("ApplicationEntity.getApplications", ApplicationEntity.class);
     } else {
       query = getEntityManager().createNamedQuery("ApplicationEntity.getApplicationsByKeyword", ApplicationEntity.class);
+      keyword = keyword.toLowerCase();
       keyword = "%" + keyword.replaceAll("%", "").replaceAll("\\*", "%") + "%";
       query.setParameter("title", keyword);
       query.setParameter("description", keyword);

--- a/app-center-services/src/main/java/org/exoplatform/appcenter/entity/ApplicationEntity.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/entity/ApplicationEntity.java
@@ -32,7 +32,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
     @NamedQuery(name = "ApplicationEntity.getAppByTitle", query = "SELECT app FROM ApplicationEntity app "
         + "WHERE app.title = :title"),
     @NamedQuery(name = "ApplicationEntity.getApplicationsByKeyword", query = "SELECT app FROM ApplicationEntity app "
-        + "WHERE app.title like :title OR app.description like :description OR LOWER(app.url) like LOWER(:url) "),
+        + "WHERE LOWER(app.title) like :title OR LOWER(app.description) like :description OR LOWER(app.url) like :url"),
     @NamedQuery(name = "ApplicationEntity.getApplications", query = "SELECT app FROM ApplicationEntity app"),
     @NamedQuery(name = "ApplicationEntity.getSystemApplications", query = "SELECT app FROM ApplicationEntity app WHERE app.system = TRUE"),
     @NamedQuery(name = "ApplicationEntity.getMandatoryActiveApps", query = "SELECT app FROM ApplicationEntity app "

--- a/app-center-services/src/main/java/org/exoplatform/appcenter/entity/ApplicationEntity.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/entity/ApplicationEntity.java
@@ -32,7 +32,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
     @NamedQuery(name = "ApplicationEntity.getAppByTitle", query = "SELECT app FROM ApplicationEntity app "
         + "WHERE app.title = :title"),
     @NamedQuery(name = "ApplicationEntity.getApplicationsByKeyword", query = "SELECT app FROM ApplicationEntity app "
-        + "WHERE app.title like :title OR app.description like :description OR app.url like :url"),
+        + "WHERE app.title like :title OR app.description like :description OR LOWER(app.url) like LOWER(:url) "),
     @NamedQuery(name = "ApplicationEntity.getApplications", query = "SELECT app FROM ApplicationEntity app"),
     @NamedQuery(name = "ApplicationEntity.getSystemApplications", query = "SELECT app FROM ApplicationEntity app WHERE app.system = TRUE"),
     @NamedQuery(name = "ApplicationEntity.getMandatoryActiveApps", query = "SELECT app FROM ApplicationEntity app "


### PR DESCRIPTION
**Problem :** search applications in the app-center is case sensitive when the app url contains uppercase letters
**Fix :**  Update search query by adding a `LOWER ()` to allow search with both uppercase and lowercase