### PR TITLE
Task-35860 Fix Drawer height for chrome on Mobile

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/appLauncher/components/AppLauncher.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/appLauncher/components/AppLauncher.vue
@@ -33,7 +33,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       temporary
       width="420"
       max-width="100vw"
-      max-height="100vh"
+      max-height="100%"
       class="appCenterDrawer"
     >
       <v-row class="mx-0 title">


### PR DESCRIPTION
When using chrome on Mobile, the height viewport isn't fix and thus, some drawers could not display its content. This fix aims to fix this use case by defining drawer height by percentage instead of viewport