### PR TITLE
MAINT-35703: Make sure that the search of applications is not case sensitive to accentuated chars.

### DIFF
--- a/app-center-services/src/main/java/org/exoplatform/appcenter/dao/ApplicationDAO.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/dao/ApplicationDAO.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import javax.persistence.TypedQuery;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.appcenter.entity.ApplicationEntity;
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
@@ -44,7 +44,7 @@ public class ApplicationDAO extends GenericDAOJPAImpl<ApplicationEntity, Long> {
       query = getEntityManager().createNamedQuery("ApplicationEntity.getApplications", ApplicationEntity.class);
     } else {
       query = getEntityManager().createNamedQuery("ApplicationEntity.getApplicationsByKeyword", ApplicationEntity.class);
-      keyword = keyword.toLowerCase();
+      keyword = StringUtils.stripAccents(keyword.toLowerCase());
       keyword = "%" + keyword.replaceAll("%", "").replaceAll("\\*", "%") + "%";
       query.setParameter("title", keyword);
       query.setParameter("description", keyword);

--- a/app-center-services/src/main/java/org/exoplatform/appcenter/dao/ApplicationDAO.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/dao/ApplicationDAO.java
@@ -44,8 +44,8 @@ public class ApplicationDAO extends GenericDAOJPAImpl<ApplicationEntity, Long> {
       query = getEntityManager().createNamedQuery("ApplicationEntity.getApplications", ApplicationEntity.class);
     } else {
       query = getEntityManager().createNamedQuery("ApplicationEntity.getApplicationsByKeyword", ApplicationEntity.class);
-      keyword = StringUtils.stripAccents(keyword.toLowerCase());
-      keyword = "%" + keyword.replaceAll("%", "").replaceAll("\\*", "%") + "%";
+      keyword = keyword.toLowerCase();
+      keyword = new StringBuilder().append("%").append(keyword.replaceAll("%", "").replaceAll("\\*", "%").replaceAll("[^\\p{ASCII}]", "_")).append("%").toString();
       query.setParameter("title", keyword);
       query.setParameter("description", keyword);
       query.setParameter("url", keyword);

--- a/app-center-services/src/test/java/org/exoplatform/appcenter/dao/ApplicationDAOTest.java
+++ b/app-center-services/src/test/java/org/exoplatform/appcenter/dao/ApplicationDAOTest.java
@@ -135,6 +135,16 @@ public class ApplicationDAOTest {
                                                                  false,
                                                                  "permissions",false);
     applicationEntity2 = service.create(applicationEntity2);
+    
+    ApplicationEntity applicationEntity3 = new ApplicationEntity(null,
+                                                                 "tést âpp",
+                                                                 "url3",
+                                                                 5L,
+                                                                 "description3",
+                                                                 true,
+                                                                 false,
+                                                                 "permissions",false);
+    applicationEntity3 = service.create(applicationEntity3);
 
     List<ApplicationEntity> applications = service.getApplications("title");
     assertNotNull(applications);
@@ -155,6 +165,16 @@ public class ApplicationDAOTest {
     assertNotNull(applications);
     assertEquals(1, applications.size());
     assertEquals(applicationEntity2.getId(), applications.get(0).getId());
+
+    applications = service.getApplications("tés");
+    assertNotNull(applications);
+    assertEquals(1, applications.size());
+    assertEquals(applicationEntity3.getId(), applications.get(0).getId());
+
+    applications = service.getApplications("âpp");
+    assertNotNull(applications);
+    assertEquals(1, applications.size());
+    assertEquals(applicationEntity3.getId(), applications.get(0).getId());
   }
 
   @Test


### PR DESCRIPTION
In order to resolve the problem of accented letters in PostgreSQL database i made sure to replace accented characters in SQL query by an underscore.