### PR TITLE
MAINT-50658: Add key for analytics app name in the appcenter for i18n

### DIFF
--- a/app-center-services/src/main/resources/locale/addon/appcenter_en.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_en.properties
@@ -27,6 +27,7 @@ appCenter.system.application.perk.store=Perk store
 appCenter.system.application.tasks=Tasks
 appCenter.system.application.wallet=Wallet
 appCenter.system.application.wiki=Notes
+appCenter.system.application.analytics=Analytics
 
 appCenter.adminSetupForm.generalSettings=Settings
 appCenter.adminSetupForm.maxFavoriteApps=Number of favorites allowed


### PR DESCRIPTION
**ISSUE**: The analytics app name is not translated when being outside the analytics app and usie the appcenter drawer
**FIX**: Add a key for the analytics app name in the app-center