### PR TITLE
51972 : Add possibility to disable applications

### DIFF
--- a/app-center-services/src/main/java/org/exoplatform/appcenter/plugin/ApplicationPlugin.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/plugin/ApplicationPlugin.java
@@ -24,6 +24,8 @@ public class ApplicationPlugin extends BaseComponentPlugin {
 
   private Application application;
 
+  private boolean     enabled;
+
   private String      imagePath;
 
   private boolean     override;
@@ -38,6 +40,12 @@ public class ApplicationPlugin extends BaseComponentPlugin {
     application = (Application) params.getObjectParam("application").getObject();
     if (application == null) {
       throw new IllegalStateException("'application' init parameter is null");
+    }
+
+    if(params.containsKey("enabled")) {
+      this.enabled = Boolean.parseBoolean(params.getValueParam("enabled").getValue());
+    } else {
+      this.enabled = true;
     }
 
     if (params.containsKey("imagePath")) {
@@ -58,6 +66,10 @@ public class ApplicationPlugin extends BaseComponentPlugin {
 
   public String getImagePath() {
     return imagePath;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
   }
 
   public boolean isOverride() {

--- a/app-center-services/src/main/java/org/exoplatform/appcenter/service/ApplicationCenterService.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/service/ApplicationCenterService.java
@@ -693,7 +693,9 @@ public class ApplicationCenterService implements Startable {
     if (StringUtils.isBlank(applicationPlugin.getName())) {
       throw new IllegalStateException("'applicationPlugin' name is mandatory");
     }
-    this.defaultApplications.put(applicationPlugin.getName(), applicationPlugin);
+    if(applicationPlugin.isEnabled()) {
+      this.defaultApplications.put(applicationPlugin.getName(), applicationPlugin);
+    }
   }
 
   /**
@@ -800,7 +802,7 @@ public class ApplicationCenterService implements Startable {
     List<Application> applications = appCenterStorage.getApplications(keyword);
     applications = applications.stream()
                                .filter(app -> hasPermission(username, app))
-                               .filter(application -> application.isActive())
+                               .filter(Application::isActive)
                                .collect(Collectors.toList());
     if (limit <= 0) {
       limit = applications.size();


### PR DESCRIPTION
Currently there is no way to disable application and make them hidden for all users and administrators to be able to continue build the app before opening it for users.
This improvement will be possible by adding the new parameter  **enabled** to the ApplicationPlugin that will control the appearance of the application in the App center administration and the app center menu.