### PR TITLE
TASK-53835 Rename Search connector for better analytics identification

### DIFF
--- a/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/search-configuration.xml
+++ b/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/search-configuration.xml
@@ -33,7 +33,7 @@
           <description>Search connector for applications</description>
           <object type="org.exoplatform.social.core.search.SearchConnector">
             <field name="name">
-              <string>application</string>
+              <string>applications</string>
             </field>
             <field name="uri">
               <string><![CDATA[/portal/rest/app-center/applications/authorized?offset=0&limit={limit}&keyword={keyword}]]></string>


### PR DESCRIPTION
Prior to this change, the name of Applications search connector was 'application' which is different from the name associated to operation collected in analytics in https://github.com/exoplatform/analytics/commit/30426a81a84c8f8ea45b7b1dd67cbfaf3cd0c276#diff-0b4b2f6d128bd203d0e84dfc2b122125e70fb551c6b9e4a78522b5e8a8ff1859R59 . In order to make this more generic, the connector name must be renamed to match already collected operation names in analytics to not break coherence of already collected analytics data.