### PR TITLE
TASK-53835 Fix Search connector labels

### DIFF
--- a/app-center-services/src/main/resources/locale/addon/appcenter_ar.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_ar.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=\u0627\u0644\u062D\u062F \u0627\u0644\u0623\u0642\u0635\u0649 \u0644\u0644\u062A\u0637\u0628\u064A\u0642\u0627\u062A
 appCenter.editpref.form.save=\u062D\u0641\u0638
-search.connector.label.application=\u062A\u0637\u0628\u064A\u0642\u0627\u062A
+search.connector.label.applications=\u062A\u0637\u0628\u064A\u0642\u0627\u062A
 
 appCenter.system.application.agenda=\u0627\u0644\u0631\u0632\u0646\u0627\u0645\u0629
 appCenter.system.application.drives=\u0627\u0644\u0623\u0642\u0631\u0627\u0635

--- a/app-center-services/src/main/resources/locale/addon/appcenter_aro.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_aro.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=\u0627\u0644\u062D\u062F \u0627\u0644\u0623\u0642\u0635\u0649 \u0644\u0644\u062A\u0637\u0628\u064A\u0642\u0627\u062A
 appCenter.editpref.form.save=\u062D\u0641\u0638
-search.connector.label.application=\u062A\u0637\u0628\u064A\u0642\u0627\u062A
+search.connector.label.applications=\u062A\u0637\u0628\u064A\u0642\u0627\u062A
 
 appCenter.system.application.agenda=\u0627\u0644\u0631\u0632\u0646\u0627\u0645\u0629
 appCenter.system.application.drives=\u0627\u0644\u0623\u0642\u0631\u0627\u0635

--- a/app-center-services/src/main/resources/locale/addon/appcenter_az.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_az.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Saxla
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drives

--- a/app-center-services/src/main/resources/locale/addon/appcenter_ca.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_ca.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Desa
-search.connector.label.application=Aplicacions
+search.connector.label.applications=Aplicacions
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Unitats

--- a/app-center-services/src/main/resources/locale/addon/appcenter_ceb.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_ceb.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Save
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Ang mga Drive

--- a/app-center-services/src/main/resources/locale/addon/appcenter_co.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_co.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Save
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drives

--- a/app-center-services/src/main/resources/locale/addon/appcenter_cs.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_cs.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Ulo\u017Eit
-search.connector.label.application=Aplikace
+search.connector.label.applications=Aplikace
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Disky

--- a/app-center-services/src/main/resources/locale/addon/appcenter_de.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_de.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Maximale Anwendungen
 appCenter.editpref.form.save=Speichern
-search.connector.label.application=Anwendungen
+search.connector.label.applications=Anwendungen
 
 appCenter.system.application.agenda=Copyright (C) 2020 eXo Platform SAS.\n\nDies ist freie Software; Sie k\u00F6nnen es weitergeben und / oder \u00E4ndern\nunter den Bedingungen der GNU Lesser General Public License als\nver\u00F6ffentlicht von der Free Software Foundation; entweder Version 2.1 von\ndie Lizenz oder (nach Ihrer Wahl) eine sp\u00E4tere Version.\n\nDiese Software wird in der Hoffnung verbreitet, dass sie n\u00FCtzlich sein wird,\naber OHNE JEGLICHE GARANTIE; ohne auch nur die implizite Garantie von\nMARKTG\u00C4NGIGKEIT oder EIGNUNG F\u00DCR EINEN BESTIMMTEN ZWECK. Siehe die GNU\nGeringere allgemeine \u00F6ffentliche Lizenz f\u00FCr weitere Details.\n\nSie sollten eine Kopie der GNU Lesser General Public erhalten haben\nLizenz zusammen mit dieser Software; Wenn nicht, schreiben Sie an die Free\nSoftware Foundation, Inc., 51 Franklin Street, 5. Stock, Boston, MA\n02110-1301 USA, oder besuchen Sie die FSF-Website: http://www.fsf.org.\n\nportal.global.agenda
 appCenter.system.application.drives=Laufwerke

--- a/app-center-services/src/main/resources/locale/addon/appcenter_el.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_el.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=\u0391\u03C0\u03BF\u03B8\u03AE\u03BA\u03B5\u03C5\u03C3\u03B7
-search.connector.label.application=\u0395\u03C6\u03B1\u03C1\u03BC\u03BF\u03B3\u03AD\u03C2
+search.connector.label.applications=\u0395\u03C6\u03B1\u03C1\u03BC\u03BF\u03B3\u03AD\u03C2
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=\u039C\u03BF\u03BD\u03AC\u03B4\u03B5\u03C2

--- a/app-center-services/src/main/resources/locale/addon/appcenter_en.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_en.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Save
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drives

--- a/app-center-services/src/main/resources/locale/addon/appcenter_es_ES.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_es_ES.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Aplicaciones m\u00E1x.
 appCenter.editpref.form.save=Guardar
-search.connector.label.application=Aplicaciones
+search.connector.label.applications=Aplicaciones
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Unidades de disco

--- a/app-center-services/src/main/resources/locale/addon/appcenter_eu.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_eu.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Save
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drives

--- a/app-center-services/src/main/resources/locale/addon/appcenter_fa.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_fa.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=\u0630\u062E\u064A\u0631\u0647
-search.connector.label.application=\u0628\u0631\u0646\u0627\u0645\u0647 \u0647\u0627\u06CC \u06A9\u0627\u0631\u0628\u0631\u062F\u06CC
+search.connector.label.applications=\u0628\u0631\u0646\u0627\u0645\u0647 \u0647\u0627\u06CC \u06A9\u0627\u0631\u0628\u0631\u062F\u06CC
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=\u062F\u0631\u0627\u06CC\u0648\u0647\u0627

--- a/app-center-services/src/main/resources/locale/addon/appcenter_fi.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_fi.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Save
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drives

--- a/app-center-services/src/main/resources/locale/addon/appcenter_fil.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_fil.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Seyb
-search.connector.label.application=Mga Aplikasyon
+search.connector.label.applications=Mga Aplikasyon
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Ang mga drive

--- a/app-center-services/src/main/resources/locale/addon/appcenter_fr.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_fr.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Nombre max des applications
 appCenter.editpref.form.save=Enregistrer
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Lecteurs

--- a/app-center-services/src/main/resources/locale/addon/appcenter_hi.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_hi.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Save
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drives

--- a/app-center-services/src/main/resources/locale/addon/appcenter_hu.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_hu.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Save
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drives

--- a/app-center-services/src/main/resources/locale/addon/appcenter_in.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_in.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Simpan
-search.connector.label.application=Aplikasi
+search.connector.label.applications=Aplikasi
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drive

--- a/app-center-services/src/main/resources/locale/addon/appcenter_it.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_it.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Applicazioni massime
 appCenter.editpref.form.save=Salva
-search.connector.label.application=Applicazioni
+search.connector.label.applications=Applicazioni
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Unit\u00E0

--- a/app-center-services/src/main/resources/locale/addon/appcenter_ja.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_ja.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=\u4FDD\u5B58
-search.connector.label.application=\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3
+search.connector.label.applications=\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=\u30C9\u30E9\u30A4\u30D6

--- a/app-center-services/src/main/resources/locale/addon/appcenter_kab.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_kab.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Save
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drives

--- a/app-center-services/src/main/resources/locale/addon/appcenter_ko.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_ko.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Save
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drives

--- a/app-center-services/src/main/resources/locale/addon/appcenter_lt.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_lt.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=I\u0161saugoti
-search.connector.label.application=Programos
+search.connector.label.applications=Programos
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Diskai

--- a/app-center-services/src/main/resources/locale/addon/appcenter_ms.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_ms.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Simpan
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drives

--- a/app-center-services/src/main/resources/locale/addon/appcenter_nl.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_nl.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Opslaan
-search.connector.label.application=Applicaties
+search.connector.label.applications=Applicaties
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drives

--- a/app-center-services/src/main/resources/locale/addon/appcenter_no.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_no.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Lagre
-search.connector.label.application=Applikasjoner
+search.connector.label.applications=Applikasjoner
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Stasjoner

--- a/app-center-services/src/main/resources/locale/addon/appcenter_pcm.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_pcm.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Save
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drives

--- a/app-center-services/src/main/resources/locale/addon/appcenter_pl.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_pl.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Zapisz
-search.connector.label.application=Aplikacje
+search.connector.label.applications=Aplikacje
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Dyski

--- a/app-center-services/src/main/resources/locale/addon/appcenter_pt_BR.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_pt_BR.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Salvar
-search.connector.label.application=Aplicativos
+search.connector.label.applications=Aplicativos
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Unidades

--- a/app-center-services/src/main/resources/locale/addon/appcenter_pt_PT.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_pt_PT.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Gravar
-search.connector.label.application=Aplica\u00E7\u00F5es
+search.connector.label.applications=Aplica\u00E7\u00F5es
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Unidades

--- a/app-center-services/src/main/resources/locale/addon/appcenter_ro.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_ro.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Aplica\u021Bii maxime
 appCenter.editpref.form.save=Salva\u0163i
-search.connector.label.application=Aplica\u0163ii
+search.connector.label.applications=Aplica\u0163ii
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drive-uri

--- a/app-center-services/src/main/resources/locale/addon/appcenter_ru.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_ru.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=\u041C\u0430\u043A\u0441. \u043F\u0440\u0438\u043B\u043E\u0436\u0435\u043D\u0438\u0439
 appCenter.editpref.form.save=\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C
-search.connector.label.application=\u041F\u0440\u0438\u043B\u043E\u0436\u0435\u043D\u0438\u044F
+search.connector.label.applications=\u041F\u0440\u0438\u043B\u043E\u0436\u0435\u043D\u0438\u044F
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=\u0414\u0438\u0441\u043A\u0438

--- a/app-center-services/src/main/resources/locale/addon/appcenter_sk.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_sk.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Save
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drives

--- a/app-center-services/src/main/resources/locale/addon/appcenter_sl.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_sl.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Shrani
-search.connector.label.application=Aplikacije
+search.connector.label.applications=Aplikacije
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Pogoni

--- a/app-center-services/src/main/resources/locale/addon/appcenter_sq.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_sq.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=crwdns6937656:0crwdne6937656:0
 appCenter.editpref.form.save=crwdns6937658:0crwdne6937658:0
-search.connector.label.application=crwdns6937660:0crwdne6937660:0
+search.connector.label.applications=crwdns6937660:0crwdne6937660:0
 
 appCenter.system.application.agenda=crwdns6937662:0crwdne6937662:0
 appCenter.system.application.drives=crwdns6937664:0crwdne6937664:0

--- a/app-center-services/src/main/resources/locale/addon/appcenter_sv_SE.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_sv_SE.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Spara
-search.connector.label.application=Program
+search.connector.label.applications=Program
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Enheter

--- a/app-center-services/src/main/resources/locale/addon/appcenter_th.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_th.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Save
-search.connector.label.application=Applications
+search.connector.label.applications=Applications
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Drives

--- a/app-center-services/src/main/resources/locale/addon/appcenter_tl.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_tl.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=Save
-search.connector.label.application=Ang mga aplikasyon
+search.connector.label.applications=Ang mga aplikasyon
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=Ang mga Drive

--- a/app-center-services/src/main/resources/locale/addon/appcenter_tr.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_tr.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Maksimum uygulama
 appCenter.editpref.form.save=Kaydet
-search.connector.label.application=Uygulamalar
+search.connector.label.applications=Uygulamalar
 
 appCenter.system.application.agenda=Ajanda
 appCenter.system.application.drives=S\u00FCr\u00FCc\u00FCler

--- a/app-center-services/src/main/resources/locale/addon/appcenter_uk.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_uk.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=\u041C\u0430\u043A\u0441\u0438\u043C\u0430\u043B\u044C\u043D\u043E \u0434\u043E\u0434\u0430\u0442\u043A\u0456\u0432
 appCenter.editpref.form.save=\u0417\u0431\u0435\u0440\u0435\u0433\u0442\u0438
-search.connector.label.application=\u0414\u043E\u0434\u0430\u0442\u043A\u0438
+search.connector.label.applications=\u0414\u043E\u0434\u0430\u0442\u043A\u0438
 
 appCenter.system.application.agenda=\u041F\u043E\u0440\u044F\u0434\u043E\u043A \u0434\u0435\u043D\u043D\u0438\u0439
 appCenter.system.application.drives=\u0414\u0438\u0441\u043A\u0438

--- a/app-center-services/src/main/resources/locale/addon/appcenter_ur_IN.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_ur_IN.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=\u0645\u062D\u0641\u0648\u0638 \u06A9\u0631\u06CC\u06BA
-search.connector.label.application=\u062F\u0631\u062E\u0648\u0627\u0633\u062A\u06CC\u06BA
+search.connector.label.applications=\u062F\u0631\u062E\u0648\u0627\u0633\u062A\u06CC\u06BA
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=\u0688\u0631\u0627\u0626\u06CC\u0648\u0632

--- a/app-center-services/src/main/resources/locale/addon/appcenter_vi.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_vi.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=L\u01B0u
-search.connector.label.application=\u1EE8ng d\u1EE5ng
+search.connector.label.applications=\u1EE8ng d\u1EE5ng
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=\u1ED4 \u0111\u0129a

--- a/app-center-services/src/main/resources/locale/addon/appcenter_zh_CN.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_zh_CN.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=\u4FDD\u5B58
-search.connector.label.application=\u5E94\u7528\u7A0B\u5E8F
+search.connector.label.applications=\u5E94\u7528\u7A0B\u5E8F
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=\u9A71\u52A8\u5668

--- a/app-center-services/src/main/resources/locale/addon/appcenter_zh_TW.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_zh_TW.properties
@@ -16,7 +16,7 @@
 #
 appCenter.editpref.form.pageSize=Max applications
 appCenter.editpref.form.save=\u5132\u5B58
-search.connector.label.application=\u61C9\u7528\u7A0B\u5F0F
+search.connector.label.applications=\u61C9\u7528\u7A0B\u5F0F
 
 appCenter.system.application.agenda=Agenda
 appCenter.system.application.drives=\u78C1\u789F\u6A5F


### PR DESCRIPTION
Due to connector name change, the i18N label key of Seach connectors has changed. This modification will ensure to apply the new computed key.