### PR TITLE
Task-53828 : Alert message displays when opening an application

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/drawer/ApplicationFormDrawer.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/drawer/ApplicationFormDrawer.vue
@@ -48,7 +48,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         type="url"
         name="url"
         class="input-block-level ignore-vuetify-classes my-3 required"
-        maxlength="200"
+        maxlength="500"
         :readonly="formArray.system"
         :placeholder="$t('appCenter.adminSetupForm.urlPlaceholder')"
         required>

--- a/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/drawer/ApplicationFormDrawer.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/drawer/ApplicationFormDrawer.vue
@@ -166,7 +166,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         class="input-block-level ignore-vuetify-classes my-3"
         type="url"
         name="name"
-        maxlength="200"
+        maxlength="500"
         :placeholder="$t('appCenter.adminSetupForm.helpPagePlaceholder')">
     </div>
     <div slot="footer" class="d-flex">


### PR DESCRIPTION
ISSUES: When creating an app with a URL longer than 200 characters, the URL entry will only take 200 characters. So it is an invalid URL.
FIX: To resolve this issue, I changed the maximum allowed length of URL entry to 500 characters