### PR TITLE
Task-55172: fix app center drawer in  domain page

### DIFF
--- a/app-center-services/src/main/resources/locale/addon/appcenter_en.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_en.properties
@@ -26,6 +26,7 @@ appCenter.system.application.notes=Notes
 appCenter.system.application.perk.store=Perks
 appCenter.system.application.tasks=Tasks
 appCenter.system.application.wallet=Wallet
+appCenter.system.application.challenges=Challenges
 appCenter.system.application.wiki=Notes
 appCenter.system.application.analytics=Analytics
 appCenter.system.application.processes=Processes


### PR DESCRIPTION
When accessing the domain page, the application center drawer was corrected: applications were displayed again