### PR TITLE
TASK-59084: Fix Conflicting setter definitions for property "permissions" of Application dto while generating swagger rest documentation

### DIFF
--- a/app-center-services/src/main/java/org/exoplatform/appcenter/dto/Application.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/dto/Application.java
@@ -198,10 +198,6 @@ public class Application implements Serializable {
     this.permissions = Arrays.asList(permissions);
   }
 
-  public void setPermissions(List<String> permissions) {
-    this.permissions = permissions;
-  }
-
   public String getImageFileBody() {
     return imageFileBody;
   }


### PR DESCRIPTION
Prior to this change, When executing the openapi maven plugin an error raised of conflicting setter definitions for property "permissions" of Application
This PR should fix this error by removing the useless unneeded setter to fix the conflict