### PR TITLE
TASK-59178: Use PATCH annotation from Meeds WS implementation

### DIFF
--- a/app-center-services/src/main/java/org/exoplatform/appcenter/rest/ApplicationCenterREST.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/rest/ApplicationCenterREST.java
@@ -36,7 +36,7 @@ import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.MembershipEntry;
 
 import io.swagger.annotations.*;
-import io.swagger.jaxrs.PATCH;
+import org.exoplatform.services.rest.http.PATCH;
 
 @Path("app-center")
 @RolesAllowed("users")


### PR DESCRIPTION
Prior to this change, Endpoints with http patch requests are using the swagger jaxrs PATCH annotation,
This PR should use the PATCH annotation from Meeds WS implementation instead of swagger jaxrs annotation