### PR TITLE
feat: Engagement Center Change application's name to contributions - MEED-604 - Meeds-io/MIPs#13

### DIFF
--- a/app-center-services/src/main/resources/locale/addon/appcenter_en.properties
+++ b/app-center-services/src/main/resources/locale/addon/appcenter_en.properties
@@ -30,6 +30,8 @@ appCenter.system.application.challenges=Challenges
 appCenter.system.application.wiki=Notes
 appCenter.system.application.analytics=Analytics
 appCenter.system.application.processes=Processes
+appCenter.system.application.contributions=Contributions
+
 
 appCenter.adminSetupForm.generalSettings=Settings
 appCenter.adminSetupForm.maxFavoriteApps=Number of favorites allowed


### PR DESCRIPTION
In order to introduce our new application Contributions in app center, many modifications has been applied,
prior to this change is was named Challenges, this change is going to change the application name to Contributions by adding a technical label to the app-center.