### PR TITLE
fix: Icons with wrong color - MEED-1480

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/myApplications/main.js
+++ b/app-center-webapps/src/main/webapp/vue-apps/myApplications/main.js
@@ -21,15 +21,12 @@ import MyApplicationsApp from './components/MyApplications.vue';
 const lang = eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || 'en';
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.addon.appcenter-${lang}.json`;
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
-
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
     Vue.createApp({
       render: h => h(MyApplicationsApp),
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, '#myApplications', 'My Application Center');
   });
 }


### PR DESCRIPTION
Prior to this change, some icons were displayed in the wrong secondary color, this was because Vuetify was overriding the color due to a non-recommended declaration
