### PR TITLE
feat: Fix app Center Pages Margins to offer coherent UX - MEED-1320 - Meeds-io/MIPs#43

### DIFF
--- a/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/portal/group/platform/administrators/pages.xml
+++ b/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/portal/group/platform/administrators/pages.xml
@@ -19,26 +19,29 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <page-set xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_3 http://www.gatein.org/xml/ns/gatein_objects_1_3"
 	xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_3">
-	<page>
-		<name>appCenterAdminSetup</name>
-		<title>App center admin setup</title>
-		<access-permissions>*:/platform/administrators</access-permissions>
-		<edit-permission>*:/platform/administrators</edit-permission>
-		<portlet-application>
-			<portlet>
-				<application-ref>app-center</application-ref>
-				<portlet-ref>AppCenterAdminSetupPortlet</portlet-ref>
-				<preferences>
-					<preference>
-						<name>pageSize</name>
-						<value>10</value>
-						<read-only>false</read-only>
-					</preference>
-				</preferences>
-			</portlet>
-			<title>App Center Admin Setup</title>
-			<access-permissions>*:/platform/administrators</access-permissions>
-			<show-info-bar>false</show-info-bar>
-		</portlet-application>
-	</page>
+  <page>
+    <name>appCenterAdminSetup</name>
+    <title>App center admin setup</title>
+    <access-permissions>*:/platform/administrators</access-permissions>
+    <edit-permission>*:/platform/administrators</edit-permission>
+    <container template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
+      <access-permissions>*:/platform/administrators</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>app-center</application-ref>
+          <portlet-ref>AppCenterAdminSetupPortlet</portlet-ref>
+          <preferences>
+            <preference>
+              <name>pageSize</name>
+              <value>10</value>
+              <read-only>false</read-only>
+            </preference>
+          </preferences>
+        </portlet>
+        <title>App Center Admin Setup</title>
+        <access-permissions>*:/platform/administrators</access-permissions>
+        <show-info-bar>false</show-info-bar>
+      </portlet-application>
+    </container>
+  </page>
 </page-set>

--- a/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/portal/portal-configuration.xml
+++ b/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/portal/portal-configuration.xml
@@ -82,7 +82,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <boolean>${exo.app-center.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>${exo.app-center.portalConfig.metadata.importmode:insert}</string>
+              <string>${exo.app-center.portalConfig.metadata.importmode:merge}</string>
             </field>
           </object>
         </object-param>
@@ -104,7 +104,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <boolean>${exo.app-center.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>${exo.app-center.portalConfig.metadata.importmode:insert}</string>
+              <string>${exo.app-center.portalConfig.metadata.importmode:merge}</string>
             </field>
             <field name="templateLocation">
               <string>war:/conf/app-center/portal</string>

--- a/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/portal/portal/global/pages.xml
+++ b/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/portal/portal/global/pages.xml
@@ -1,31 +1,30 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
-This file is part of the Meeds project (https://meeds.io/).
-Copyright (C) 2020 Meeds Association
-contact@meeds.io
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 3 of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-You should have received a copy of the GNU Lesser General Public License
-along with this program; if not, write to the Free Software Foundation,
-Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2020 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 -->
-
-
 <page-set>
   <page>
     <name>appCenterUserSetup</name>
     <title>App Center User Setup</title>
     <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
     <edit-permission>manager:/platform/administrators</edit-permission>
-    <container id="AppCenterUserSetup"
-      template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
+    <container id="AppCenterUserSetup" template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
       <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
       <portlet-application>
         <portlet>

--- a/app-center-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/app-center-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -30,6 +30,18 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <name>AppCenterAdminSetupPortlet</name>
     <module>
       <depends>
+        <module>vue</module>
+      </depends>
+      <depends>
+        <module>vuetify</module>
+      </depends>
+      <depends>
+        <module>eXoVueI18n</module>
+      </depends>
+      <depends>
+        <module>commonVueComponents</module>
+      </depends>
+      <depends>
         <module>adminSetupPortletBundle</module>
       </depends>
     </module>
@@ -38,6 +50,18 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <portlet>
     <name>AppCenterUserSetupPortlet</name>
     <module>
+      <depends>
+        <module>vue</module>
+      </depends>
+      <depends>
+        <module>vuetify</module>
+      </depends>
+      <depends>
+        <module>eXoVueI18n</module>
+      </depends>
+      <depends>
+        <module>commonVueComponents</module>
+      </depends>
       <depends>
         <module>userSetupPortletBundle</module>
       </depends>
@@ -48,6 +72,18 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <name>AppCenterMyApplicationsPortlet</name>
     <module>
       <depends>
+        <module>vue</module>
+      </depends>
+      <depends>
+        <module>vuetify</module>
+      </depends>
+      <depends>
+        <module>eXoVueI18n</module>
+      </depends>
+      <depends>
+        <module>commonVueComponents</module>
+      </depends>
+      <depends>
         <module>myApplicationsBundle</module>
       </depends>
     </module>
@@ -56,6 +92,18 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <portlet>
     <name>AppCenterAppLauncherPortlet</name>
     <module>
+      <depends>
+        <module>vue</module>
+      </depends>
+      <depends>
+        <module>vuetify</module>
+      </depends>
+      <depends>
+        <module>eXoVueI18n</module>
+      </depends>
+      <depends>
+        <module>commonVueComponents</module>
+      </depends>
       <depends>
         <module>appLauncherBundle</module>
       </depends>

--- a/app-center-webapps/src/main/webapp/skin/less/app-center.less
+++ b/app-center-webapps/src/main/webapp/skin/less/app-center.less
@@ -18,8 +18,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 /* This file contains CSS for admin setup portlet */
 .applicationsAdmin {
-  margin: 20px;
-  padding: 10px;
   background: @baseBackgroundDefault !important;
   border-radius: 6px;
   box-shadow: 0 2px 9px 0 rgba(0, 0, 0, 0.02);
@@ -396,8 +394,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 }
 /* This file contains CSS for user setup portlet */
 .userApplications {
-  margin: 20px;
-  padding: 10px;
   border-radius: 6px;
   box-shadow: 0 2px 9px 0 rgba(0, 0, 0, 0.02);
   .appImage {

--- a/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/AdminSetup.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/AdminSetup.vue
@@ -15,35 +15,47 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app class="applicationsAdmin">
-    <v-row class="uiTabNormal uiTabInPage white">
-      <v-col>
-        <v-tabs
-          class="appAdminTabs"
-          background-color="transparent">
-          <v-tab @click="loadApplicationsList">
-            {{ $t('appCenter.adminSetupForm.applications') }}
-          </v-tab>
-          <v-tab>
-            {{ $t('appCenter.adminSetupForm.generalSettings') }}
-          </v-tab>
+  <v-app
+    id="KudosAdminApp"
+    class="applicationsAdmin">
+    <main>
+      <v-layout>
+        <v-flex>
+          <v-tabs
+            v-model="selectedTab"
+            slider-size="4">
+            <v-tab key="applications" href="#applications" @click="loadApplicationsList">
+              {{ $t('appCenter.adminSetupForm.applications') }}
+            </v-tab>
+            <v-tab key="settings" href="#settings">
+              {{ $t('appCenter.adminSetupForm.generalSettings') }}
+            </v-tab>
+          </v-tabs>
 
-          <v-tab-item class="px-4 py-2">
-            <adminSetup-list :key="adminSetupListKey" />
-          </v-tab-item>
-          <v-tab-item class="px-4 py-2">
-            <adminSetup-generalParams />
-          </v-tab-item>
-        </v-tabs>        
-      </v-col>
-    </v-row>
+          <v-tabs-items v-model="selectedTab" class="mt-2">
+            <v-tab-item
+              id="applications"
+              value="applications"
+              class="px-4 py-2">
+              <adminSetup-list :key="adminSetupListKey" />
+            </v-tab-item>
+            <v-tab-item
+              id="settings"
+              value="settings"
+              class="px-4 py-2">
+              <adminSetup-generalParams />
+            </v-tab-item>
+          </v-tabs-items>
+        </v-flex>
+      </v-layout>
+    </main>
   </v-app>
 </template>
-
 <script>
 export default {
   data() {
     return {
+      selectedTab: 'applications',
       adminSetupListKey: 0,
     };
   },

--- a/app-center-webapps/src/main/webapp/vue-apps/adminSetup/main.js
+++ b/app-center-webapps/src/main/webapp/vue-apps/adminSetup/main.js
@@ -20,29 +20,18 @@ import './initComponents.js';
 const lang = eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || 'en';
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.addon.appcenter-${lang}.json`;
 
-
-Vue.use(Vuetify);
-const vuetify = new Vuetify({
-  dark: true,
-  iconfont: ''
-});
-
 const appId = 'adminSetup';
 
 export function init(preferences) {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
-    const appElement = document.createElement('div');
-    appElement.id = appId;
-
     Vue.createApp({
       data: {
         preferences: preferences,
       },
       template: `<app-center-admin-setup
-                  id="${appId}"
-                  v-cacheable />`,
-      vuetify,
+                  id="${appId}" />`,
+      vuetify: Vue.prototype.vuetifyOptions,
       i18n,
-    }, appElement, 'Application Center Administration');
+    }, `#${appId}`, 'Application Center Administration');
   });
 }


### PR DESCRIPTION
This change will delete inner margins of application to let the portal manage margins in a centralized way using CSS Helpers Classes. Besides, the default importMode has been changed into `MERGE` to reimport the page in old installations.