### PR TITLE
fix: Avoid logging warn in server startup - Meeds-io/meeds#598

### DIFF
--- a/app-center-webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/app-center-webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -133,7 +133,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <mime-type>text/html</mime-type>
     </supports>
     <supported-locale>en</supported-locale>
-    <resource-bundle>locale.addon.status</resource-bundle>
+    <resource-bundle>locale.addon.appcenter</resource-bundle>
     <portlet-info>
       <title>App center app launcher portlet</title>
       <keywords>App center portlets</keywords>


### PR DESCRIPTION
Prior to this change, the AppCenter portlet references a missing resource bundle. This fix will reference in portlet definition the used locale 'locale.addon.appcenter' instead of the missing one.