### PR TITLE
fix : Increase the application center permission column max length - EXO-66927 - Meeds-io/meeds#1240

### DIFF
--- a/app-center-services/src/main/resources/db.changelogs/app-center-changelog-1.0.0.xml
+++ b/app-center-services/src/main/resources/db.changelogs/app-center-changelog-1.0.0.xml
@@ -123,4 +123,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <createSequence sequenceName="SEQ_APPLICATION_ID" startValue="1" />
     <createSequence sequenceName="SEQFAVORITE_APPLICATION_ID" startValue="1" />
   </changeSet>
+  <changeSet author="appCenter" id="1.0.0-10">
+    <modifyDataType columnName="PERMISSIONS"
+                    newDataType="VARCHAR(2000)"
+                    tableName="AC_APPLICATION"/>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Prior to this change when we attempting to adding multiple group permissions to the application center, permissions exceeding 255 character were not saved .
This change is going to increase the application center permission column max length .