### PR TITLE
fix: Fix the empty application center list on a new server - EXO-68230 - Meeds-io/meeds#1462

### DIFF
--- a/app-center-services/src/main/java/org/exoplatform/appcenter/service/ApplicationCenterService.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/service/ApplicationCenterService.java
@@ -270,7 +270,7 @@ public class ApplicationCenterService implements Startable {
       throw new ApplicationAlreadyExistsException("An application with same title already exists");
     }
 
-    if (!isUrlValid(application.getUrl()) || (!application.getHelpPageURL().isBlank() && !isUrlValid(application.getHelpPageURL()))) {
+    if (!isUrlValid(application.getUrl()) || (application.getHelpPageURL() != null && !application.getHelpPageURL().isBlank() && !isUrlValid(application.getHelpPageURL()))) {
       throw new MalformedURLException();
     }
 


### PR DESCRIPTION
Prior to this change a null pointer exception was thrown during the injection process of the default applications. This exception was caused by the unchecked null value of the help page URL. This change addresses this issue