### PR TITLE
feat: Cleanup Dependencies to rely on Spring Dependencies Tree - Meeds-io/MIPs#57

### DIFF
--- a/app-center-services/pom.xml
+++ b/app-center-services/pom.xml
@@ -31,7 +31,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>App-center addon rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.71</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.72</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>
@@ -53,12 +53,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <dependency>
       <groupId>org.exoplatform.social</groupId>
       <artifactId>social-component-service</artifactId>
-    </dependency>
-    <!-- swagger -->
-    <dependency>
-      <groupId>io.swagger.core.v3</groupId>
-      <artifactId>swagger-annotations</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>

--- a/app-center-services/src/main/java/org/exoplatform/appcenter/dao/ApplicationDAO.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/dao/ApplicationDAO.java
@@ -18,9 +18,9 @@ package org.exoplatform.appcenter.dao;
 
 import java.util.List;
 
-import javax.persistence.TypedQuery;
+import jakarta.persistence.TypedQuery;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.appcenter.entity.ApplicationEntity;
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;

--- a/app-center-services/src/main/java/org/exoplatform/appcenter/dao/FavoriteApplicationDAO.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/dao/FavoriteApplicationDAO.java
@@ -18,7 +18,7 @@ package org.exoplatform.appcenter.dao;
 
 import java.util.List;
 
-import javax.persistence.TypedQuery;
+import jakarta.persistence.TypedQuery;
 
 import org.exoplatform.appcenter.entity.FavoriteApplicationEntity;
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;

--- a/app-center-services/src/main/java/org/exoplatform/appcenter/entity/ApplicationEntity.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/entity/ApplicationEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.appcenter.entity;
 
 import java.util.Collection;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 

--- a/app-center-services/src/main/java/org/exoplatform/appcenter/entity/FavoriteApplicationEntity.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/entity/FavoriteApplicationEntity.java
@@ -16,7 +16,7 @@
  */
 package org.exoplatform.appcenter.entity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 

--- a/app-center-services/src/main/java/org/exoplatform/appcenter/service/ApplicationCenterService.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/service/ApplicationCenterService.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import java.util.Base64;
 import org.picocontainer.Startable;
 

--- a/app-center-services/src/main/java/org/exoplatform/appcenter/storage/ApplicationCenterStorage.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/storage/ApplicationCenterStorage.java
@@ -25,7 +25,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import java.util.Base64;
 
 import org.exoplatform.appcenter.dao.ApplicationDAO;

--- a/app-center-services/src/test/resources/conf/configuration.xml
+++ b/app-center-services/src/test/resources/conf/configuration.xml
@@ -31,38 +31,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </init-params>
   </component>
 
-  <!-- Bind datasource -->
-  <external-component-plugins>
-    <target-component>org.exoplatform.services.naming.InitialContextInitializer</target-component>
-    <component-plugin>
-      <name>bind.datasource</name>
-      <set-method>addPlugin</set-method>
-      <type>org.exoplatform.services.naming.BindReferencePlugin</type>
-      <init-params>
-        <value-param>
-          <name>bind-name</name>
-          <value>java:/comp/env/exo-jpa_portal</value>
-        </value-param>
-        <value-param>
-          <name>class-name</name>
-          <value>javax.sql.DataSource</value>
-        </value-param>
-        <value-param>
-          <name>factory</name>
-          <value>org.apache.commons.dbcp.BasicDataSourceFactory</value>
-        </value-param>
-        <properties-param>
-          <name>ref-addresses</name>
-          <description>ref-addresses</description>
-          <property name="driverClassName" value="org.hsqldb.jdbcDriver"/>
-          <property name="url" value="jdbc:hsqldb:mem:db1"/>
-          <property name="username" value="sa"/>
-          <property name="password" value=""/>
-        </properties-param>
-      </init-params>
-    </component-plugin>
-  </external-component-plugins>
-
   <!-- Removed here to let it instanciated on portal container after InitialContextInitializer service is started -->
   <remove-configuration>org.exoplatform.commons.api.persistence.DataInitializer</remove-configuration>
 </configuration>

--- a/app-center-webapps/pom.xml
+++ b/app-center-webapps/pom.xml
@@ -29,8 +29,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <name>Add-on:: Application Center - Webapp</name>
   <dependencies>
     <dependency>
-      <groupId>javax.portlet</groupId>
-      <artifactId>portlet-api</artifactId>
+      <groupId>org.exoplatform.gatein.portal</groupId>
+      <artifactId>exo.portal.component.api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This change will upgrade from Commons Lang to Apache Lang 3 and will recompute the score of Tests coverage after excluding globally the POJOs from computation scopre computing. ( see https://github.com/Meeds-io/maven-parent-pom/pull/45 )