### PR TITLE
fix: App center - Application help icon is mis-placed - EXO-71815 - Meeds-io/meeds#2035.

### DIFF
--- a/app-center-webapps/src/main/webapp/skin/less/app-center.less
+++ b/app-center-webapps/src/main/webapp/skin/less/app-center.less
@@ -530,7 +530,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               position: relative;
               margin: 0;
               .v-icon {
-                color: @greyColorLighten2!important;
+                color: @greyColorLighten1!important;
+                bottom: -1px;
               }
             }
           }

--- a/app-center-webapps/src/main/webapp/vue-apps/userSetup/components/UserAuthorizedApplications.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/userSetup/components/UserAuthorizedApplications.vue
@@ -133,8 +133,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                       icon
                       @click="navigateTo(authorizedApp.helpPageURL)">
                       <v-icon
-                        small>
-                        fas fa-question-circle
+                        x-small>
+                        mdi-help
                       </v-icon>
                     </v-btn>
                     <div :title="getTooltip(authorizedApp)">


### PR DESCRIPTION
Before this change, when,add a hlep url on any app & save and display app center and check? icon displayed, the icon ? location is wrong. After this change, the ? icon is on the bottom of the card next to the bookmark icon on the left.