### PR TITLE
feat : remove distinction between mandatory and favorites app in app drawer - EXO-72002

### DIFF
--- a/app-center-services/src/main/java/org/exoplatform/appcenter/service/ApplicationCenterService.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/service/ApplicationCenterService.java
@@ -569,8 +569,13 @@ public class ApplicationCenterService implements Startable {
    *         {@link UserApplication}
    */
   public ApplicationList getMandatoryAndFavoriteApplicationsList(String username) {
-    List<UserApplication> mandatoryAndFavoriteApplications = appCenterStorage.getMandatoryApplications();
-    mandatoryAndFavoriteApplications.addAll(appCenterStorage.getFavoriteApplicationsByUser(username));
+    List<UserApplication> mandatoryAndFavoriteApplications = appCenterStorage.getFavoriteApplicationsByUser(username);
+    List<Long> mandatoryAndFavoriteApplicationsId = mandatoryAndFavoriteApplications.stream().map(userApplication -> userApplication.getId()).collect(Collectors.toList());
+    appCenterStorage.getMandatoryApplications().forEach(userApplication -> {
+      if (!mandatoryAndFavoriteApplicationsId.contains(userApplication.getId())) {
+        mandatoryAndFavoriteApplications.add(userApplication);
+      }
+    });
     List<Application> applications = mandatoryAndFavoriteApplications.stream()
                                                                      .filter(app -> hasPermission(username, app))
                                                                      .collect(Collectors.toList());

--- a/app-center-services/src/main/java/org/exoplatform/appcenter/storage/ApplicationCenterStorage.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/storage/ApplicationCenterStorage.java
@@ -170,13 +170,14 @@ public class ApplicationCenterStorage {
     favoriteApplicationDAO.create(new FavoriteApplicationEntity(application, username));
   }
 
-  public void updateFavoriteApplicationOrder(long applicationId, String username, Long order) {
+  public void updateFavoriteApplicationOrder(long applicationId, String username, Long order) throws ApplicationNotFoundException {
     FavoriteApplicationEntity entity = favoriteApplicationDAO.getFavoriteAppByUserNameAndAppId(applicationId, username);
-    // check if it is a favorite application and not a system application
-    if (entity != null && !entity.getApplication().isMandatory()) {
-      entity.setOrder(order);
-      favoriteApplicationDAO.update(entity);
+    if (entity == null) {
+      addApplicationToUserFavorite(applicationId, username);
+      entity = favoriteApplicationDAO.getFavoriteAppByUserNameAndAppId(applicationId, username);
     }
+    entity.setOrder(order);
+    favoriteApplicationDAO.update(entity);
   }
 
   public void deleteApplicationFavorite(Long applicationId, String username) {
@@ -204,7 +205,7 @@ public class ApplicationCenterStorage {
     List<FavoriteApplicationEntity> applications = favoriteApplicationDAO.getFavoriteAppsByUser(username);
     return applications.stream()
                        .map(this::toUserApplicationDTO)
-                       .filter(userApplication -> userApplication.isActive() && !userApplication.isMandatory())
+                       .filter(userApplication -> userApplication.isActive())
                        .collect(Collectors.toList());
   }
 

--- a/app-center-webapps/src/main/webapp/vue-apps/appLauncher/components/AppLauncherDrawer.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/appLauncher/components/AppLauncherDrawer.vue
@@ -42,49 +42,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         v-if="hasApplications"
         slot="content"
         class="content">
-        <v-row v-if="mandatoryApplicationsList.length > 0" class="mandatory appsContainer">
-          <v-col v-model="mandatoryApplicationsList" class="appLauncherList">
-            <div
-              v-for="(application, index) in mandatoryApplicationsList"
-              :id="'Pos-' + index"
-              :key="index"
-              class="appLauncherItemContainer">
-              <div
-                :id="'App-' + index"
-                class="appLauncherItem">
-                <a
-                  :id="application.id"
-                  :target="application.target"
-                  :href="application.computedUrl"
-                  @click="logOpenApplication(application.id)">
-                  <img
-                    v-if="application.imageFileId && application.imageFileName"
-                    class="appLauncherImage"
-                    referrerpolicy="no-referrer"
-                    :src="`/portal/rest/app-center/applications/illustration/${application.id}?v=${application.imageLastModified}`">
-                  <img
-                    v-else-if="defaultAppImage.fileBody"
-                    class="appLauncherImage"
-                    referrerpolicy="no-referrer"
-                    :src="`/portal/rest/app-center/applications/illustration/${application.id}?v=${application.imageLastModified}`">
-                  <img
-                    v-else
-                    class="appLauncherImage"
-                    referrerpolicy="no-referrer"
-                    src="/app-center/skin/images/defaultApp.png">
-                  <span
-                    v-exo-tooltip.bottom.body="application.title.length > 22 ? application.title : ''"
-                    class="appLauncherTitle">
-                    {{ application.title }}
-                  </span>
-                </a>
-              </div>
-            </div>
-          </v-col>
-        </v-row>
-        <v-row v-if="favoriteApplicationsList.length > 0" class="appsContainer">
-          <v-divider />
-        </v-row>
         <v-layout v-if="favoriteApplicationsList.length > 0" class="favorite appsContainer">
           <draggable
             v-model="favoriteApplicationsList"
@@ -174,7 +131,6 @@ export default {
       },
       isMobileDevice: false,
       applicationsLoaded: false,
-      mandatoryApplicationsList: [],
       favoriteApplicationsList: [],
       applicationsOrder: null,
       appCenterUserSetupLink: '',
@@ -217,7 +173,7 @@ export default {
   },
   computed: {
     hasApplications() {
-      return this.mandatoryApplicationsList?.length || this.favoriteApplicationsList?.length;
+      return this.favoriteApplicationsList?.length;
     },
   },
   created() {
@@ -275,6 +231,7 @@ export default {
           }
         })
         .then(data => {
+          console.log('getMandatoryAndFavoriteApplications, data=',data);
           // manage system apps localized names
           data.applications.forEach(app => {
             if (app.system) {
@@ -290,46 +247,45 @@ export default {
           } else {
             applications.push(...data.applications);
           }
-          this.mandatoryApplicationsList = applications.filter(app => app.mandatory && !app.favorite);
-          // sort mandatory applications alphabetical
-          this.mandatoryApplicationsList.sort((a, b) => {
-            if (a.title < b.title) {
-              return -1;
-            }
-
-            if (a.title > b.title) {
-              return 1;
-            }
-
-            return 0;
-          });
-          this.favoriteApplicationsList = applications.filter(app => app.favorite && !app.mandatory);
+          this.favoriteApplicationsList = applications.filter(app => app.favorite || app.mandatory);
           // sort favorite applications alphabetically by default
           if (this.favoriteApplicationsList.some(app => app.order !== null)) {
             this.alphabeticalOrder = false;
-          } else {
-            this.favoriteApplicationsList.sort((a, b) => {
+          }
+
+          this.favoriteApplicationsList.sort((a, b) => {
+            if (typeof a.order === 'undefined' && typeof b.order === 'undefined') {
               if (a.title < b.title) {
                 return -1;
               }
-
               if (a.title > b.title) {
                 return 1;
               }
-
               return 0;
-            });            
-          }
+            }
+            if (a.order && typeof b.order === 'undefined') {
+              return -1;
+            }
+            if (typeof a.order === 'undefined' && b.order) {
+              return 1;
+            }
+            if (a.order === b.order) {
+              if (a.title < b.title) {
+                return -1;
+              }
+              if (a.title > b.title) {
+                return 1;
+              }
+              return 0;
+            }
+            return a.order - b.order;
+
+          });
+
           // store favorite applications order
           this.applicationsOrder = {};
           this.favoriteApplicationsList.forEach(app => {
             this.applicationsOrder[`${app.id}`] = this.favoriteApplicationsList.indexOf(app);
-          });
-          
-          this.mandatoryApplicationsList.forEach(app => {
-            app.computedUrl = app.url.replace(/^\.\//, `${eXo.env.portal.context}/${eXo.env.portal.portalName}/`);
-            app.computedUrl = app.computedUrl.replace('@user@', eXo.env.portal.userName);
-            app.target = app.computedUrl.indexOf('/') === 0 ? '_self' : '_blank';
           });
           this.favoriteApplicationsList.forEach(app => {
             app.computedUrl = app.url.replace(/^\.\//, `${eXo.env.portal.context}/${eXo.env.portal.portalName}/`);
@@ -339,6 +295,7 @@ export default {
         }).finally(() => this.loading = false);
     },
     updateApplicationsOrder(applicationsOrder) {
+      console.log('updateApplicationsOrder=',applicationsOrder);
       return fetch('/portal/rest/app-center/applications/favorites', {
         headers: {
           'Content-Type': 'application/json'

--- a/app-center-webapps/src/main/webapp/vue-apps/userSetup/components/UserFavoriteApplications.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/userSetup/components/UserFavoriteApplications.vue
@@ -177,36 +177,37 @@ export default {
               allApplications.push(...data.applications);
             }
           }
-          const mandatoryApps = allApplications.filter(app => app.mandatory && !app.favorite);
-          const favoriteApps = allApplications.filter(app => app.favorite && !app.mandatory);
-          mandatoryApps.sort((a, b) => {
-            if (a.title < b.title) {
-              return -1;
-            }
+          this.favoriteApplicationsList = allApplications;
 
-            if (a.title > b.title) {
-              return 1;
-            }
-
-            return 0;
-          });
           // check if favorite applications are alphabetically ordered
-          if (!favoriteApps.some(app => app.order !== null)) {
-            favoriteApps.sort((a, b) => {
+          this.favoriteApplicationsList.sort((a, b) => {
+            if (typeof a.order === 'undefined' && typeof b.order === 'undefined') {
               if (a.title < b.title) {
                 return -1;
               }
-
               if (a.title > b.title) {
                 return 1;
               }
-
               return 0;
-            });
-          }
-          this.favoriteApplicationsList = [];
-          this.favoriteApplicationsList.push(...mandatoryApps);
-          this.favoriteApplicationsList.push(...favoriteApps);
+            }
+            if (a.order && typeof b.order === 'undefined') {
+              return -1;
+            }
+            if (typeof a.order === 'undefined' && b.order) {
+              return 1;
+            }
+            if (a.order === b.order) {
+              if (a.title < b.title) {
+                return -1;
+              }
+              if (a.title > b.title) {
+                return 1;
+              }
+              return 0;
+            }
+            return a.order - b.order;
+          });
+
           this.favoriteApplicationsList.forEach(app => {
             app.computedUrl = app.url.replace(/^\.\//, `${eXo.env.portal.context}/${eXo.env.portal.portalName}/`);
             app.computedUrl = app.computedUrl.replace('@user@', eXo.env.portal.userName);


### PR DESCRIPTION
Before this fix, mandatory and favorites apps are separated in app center drawer This fix will merge both lists and allow to reorder application, no matter it is a fav or a mandatory one

Resolves meeds-io/meeds#2047

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
