### PR TITLE
fix: App center - Application description exceeds border - EXO-71810 - Meeds-io/meeds#2003

### DIFF
--- a/app-center-webapps/src/main/webapp/skin/less/app-center.less
+++ b/app-center-webapps/src/main/webapp/skin/less/app-center.less
@@ -474,7 +474,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 overflow: hidden;
                 text-overflow: ellipsis;
                 display: -webkit-box;
-                -webkit-line-clamp: 3; /* number of lines to show */
+                -webkit-line-clamp: 2; /* number of lines to show */
                 -webkit-box-orient: vertical;
               }
             }


### PR DESCRIPTION
Before this change, when, create new application in app center admin, new application description is long and display application center, new app created description exceeds the card limit. After this change, App center description is truncated and app card is remained as the other default ones.

(cherry picked from commit 6aea123ad58c410c72d7e96bed244bd021521e02)