### PR TITLE
feat: Redefine Parent applications Classes to fit layout style properties - MEED-7094 - Meeds-io/MIPs#144

### DIFF
--- a/app-center-webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/app-center-webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -74,6 +74,10 @@
       <name>prefetch.resource.rest</name>
       <value><![CDATA[/app-center/rest/settings,/app-center/rest/applications?offset=0&limit=12&keyword=,/app-center/rest/favorites]]></value>
     </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-background-color no-layout-border-radius no-layout-border</value>
+    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
       <portlet-mode>edit</portlet-mode>
@@ -132,6 +136,10 @@
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
       <value>/WEB-INF/jsp/appCenter/appLauncher.jsp</value>
+    </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
     </init-param>
     <expiration-cache>-1</expiration-cache>
     <supports>

--- a/app-center-webapps/src/main/webapp/skin/less/app-center.less
+++ b/app-center-webapps/src/main/webapp/skin/less/app-center.less
@@ -75,7 +75,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     justify-content: space-between;
   }
   .appCenter-form {
-  	background: @baseBackgroundDefault;
     min-height: 100px;
     border-radius: 6px;
     box-shadow: 0 2px 9px 0 rgba(0,0,0,0.02);
@@ -136,7 +135,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     margin-right: 0;
   }
   .generalParams .form-container {
-    background: @baseBackgroundDefault;
     padding-bottom: 0;
     min-height: inherit;
     border-radius: 0;
@@ -294,7 +292,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         color: @primaryColorDefault;
       }
       .v-text-field__slot {
-        height: 58px!important;
         &:focus {
           outline: none!important;
         }
@@ -556,7 +553,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           color: @primaryColorDefault;
         }
         .v-text-field__slot {
-          height: 58px!important;
           &:focus {
             outline: none!important;
           }

--- a/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/AdminSetup.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/AdminSetup.vue
@@ -18,13 +18,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <v-app
     id="KudosAdminApp"
     class="applicationsAdmin">
-    <main>
+    <main class="application-body">
       <v-layout>
         <v-flex>
           <v-tabs
             v-model="selectedTab"
-            slider-size="4"
-            class="card-border-radius overflow-hidden app-background-color">
+            slider-size="4">
             <v-tab
               key="applications"
               href="#applications"
@@ -36,7 +35,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             </v-tab>
           </v-tabs>
 
-          <v-tabs-items v-model="selectedTab" class="mt-2 card-border-radius app-background-color overflow-hidden">
+          <v-tabs-items v-model="selectedTab" class="mt-2">
             <v-tab-item
               id="applications"
               value="applications"

--- a/app-center-webapps/src/main/webapp/vue-apps/userSetup/components/UserSetup.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/userSetup/components/UserSetup.vue
@@ -15,16 +15,18 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <div class="userApplications">
-    <v-row dense>
-      <v-col class="authorizedApplicationsContainer card-border-radius">
-        <user-authorizedApplications :can-add-favorite="canAddFavorite" :default-app-image="defaultAppImage" />
-      </v-col>
-      <v-col class="userFavoriteApplicationsContainer card-border-radius" sm="3">
-        <user-favoriteApplications :default-app-image="defaultAppImage" @canAddFavorite="setCanAddFavorite" />
-      </v-col>      
-    </v-row>
-  </div>
+  <v-app>
+    <div class="userApplications application-body">
+      <v-row dense>
+        <v-col class="authorizedApplicationsContainer application-background-color application-border application-border-radius">
+          <user-authorizedApplications :can-add-favorite="canAddFavorite" :default-app-image="defaultAppImage" />
+        </v-col>
+        <v-col class="userFavoriteApplicationsContainer application-background-color application-border application-border-radius" sm="3">
+          <user-favoriteApplications :default-app-image="defaultAppImage" @canAddFavorite="setCanAddFavorite" />
+        </v-col>      
+      </v-row>
+    </div>
+  </v-app>
 </template>
 
 <script>

--- a/app-center-webapps/src/main/webapp/vue-apps/userSetup/main.js
+++ b/app-center-webapps/src/main/webapp/vue-apps/userSetup/main.js
@@ -36,6 +36,7 @@ export function init(preferences) {
                    :preferences="preferences"
                    v-cacheable />`,
       i18n,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, appElement, 'User Settings Application Center');
   });
 }


### PR DESCRIPTION
This change will apply **application-body** class to the main body of applications to make sure to apply layout specific CSS styles, such as disabling default Vuetify White Background applied on v-card. At the same time, for Top Toolbar applications, this will disable branding styling to avoid having border radius and other styles applied on small buttons added in Top bar as applications.