### PR TITLE
fix: improved updateApplication method code to be compatible with createApplication - EXO-72513 - Meeds-io/meeds#2216

### DIFF
--- a/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterService.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterService.java
@@ -198,6 +198,9 @@ public class ApplicationCenterService {
     if (applicationId == null) {
       throw new IllegalArgumentException(APPLICATION_ID_IS_MANDATORY_MESSAGE);
     }
+    if (!isUrlValid(application.getUrl())) {
+      throw new IllegalArgumentException("appcenter.malformedUrl");
+    }
     Application storedApplication = appCenterStorage.getApplicationById(applicationId);
     if (storedApplication == null) {
       throw new ApplicationNotFoundException(String.format(APPLICATION_NOT_FOUND_MESSAGE, applicationId));


### PR DESCRIPTION
Before this change, the updateApplication method of the ApplicationCenterService service was missing the URL validity check. To fix this, add an exception of type IllegalArgumentException as it is in the createApp method. After this change, this method is compatible with createApplication.

(cherry picked from commit 13cbf52868693e70be120cb85c19348ca4389b0e)