### PR TITLE
fix: improve updateApplication method to be compatible with createApplication - EXO-72513 - Meeds-io/meeds#2216

### DIFF
--- a/app-center-services/src/main/java/org/exoplatform/appcenter/service/ApplicationCenterService.java
+++ b/app-center-services/src/main/java/org/exoplatform/appcenter/service/ApplicationCenterService.java
@@ -318,6 +318,9 @@ public class ApplicationCenterService implements Startable {
     if (applicationId == null) {
       throw new ApplicationNotFoundException("Application with null id wasn't found");
     }
+    if (!isUrlValid(application.getUrl())) {
+    throw new IllegalArgumentException("appcenter.malformedUrl");
+    }
     Application storedApplication = appCenterStorage.getApplicationById(applicationId);
     if (storedApplication == null) {
       throw new ApplicationNotFoundException("Application with id " + applicationId + " wasn't found");


### PR DESCRIPTION
Before this change, the updateApplication method of the ApplicationCenterService service was missing the URL validity check. To fix this, add an exception of type IllegalArgumentException as it is in the createApp method. After this change, this method is compatible with createApplication.

(cherry picked from commit https://github.com/Meeds-io/app-center/commit/13cbf52868693e70be120cb85c19348ca4389b0e)