### PR TITLE
fix: [AppCenter] Searching and listing applications is KO - EXO-74206

### DIFF
--- a/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterService.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterService.java
@@ -385,12 +385,13 @@ public class ApplicationCenterService {
   public ApplicationList getApplications(int offset, int limit, String keyword) {
     ApplicationList applicationList = new ApplicationList();
     List<Application> applications = appCenterStorage.getApplications(keyword);
+    int totalApplictions = applications.size();
     if (limit <= 0) {
       limit = applications.size();
     }
     applications = applications.stream().skip(offset).limit(limit).toList();
     applicationList.setApplications(applications);
-    applicationList.setSize(applications.size());
+    applicationList.setSize(totalApplictions);
     applicationList.setOffset(offset);
     applicationList.setLimit(limit);
     return applicationList;
@@ -422,6 +423,7 @@ public class ApplicationCenterService {
     }
     ApplicationList resultApplicationsList = new ApplicationList();
     List<Application> applications = getActiveApplications(keyword, username).stream().toList();
+    int totalApplication = applications.size();
     if (limit > 0) {
       if (offset < 0) {
         offset = 0;
@@ -444,7 +446,7 @@ public class ApplicationCenterService {
     resultApplicationsList.setCanAddFavorite(countFavorites < getMaxFavoriteApps());
     resultApplicationsList.setOffset(offset);
     resultApplicationsList.setLimit(limit);
-    resultApplicationsList.setSize(applications.size());
+    resultApplicationsList.setSize(totalApplication);
     return resultApplicationsList;
   }
 

--- a/app-center-services/src/test/java/io/meeds/appcenter/service/ApplicationCenterServiceTest.java
+++ b/app-center-services/src/test/java/io/meeds/appcenter/service/ApplicationCenterServiceTest.java
@@ -292,7 +292,7 @@ public class ApplicationCenterServiceTest {
     assertNotNull(applicationsList);
     assertNotNull(applicationsList.getApplications());
     assertEquals(0, applicationsList.getApplications().size());
-    assertEquals(0, applicationsList.getSize());
+    assertEquals(1, applicationsList.getSize());
     assertEquals(1, applicationsList.getOffset());
     assertEquals(2, applicationsList.getLimit());
 
@@ -303,6 +303,44 @@ public class ApplicationCenterServiceTest {
     assertEquals(1, applicationsList.getSize());
     assertEquals(0, applicationsList.getOffset());
     assertEquals(2, applicationsList.getLimit());
+  }
+
+
+  @Test
+  @SneakyThrows
+  void getPaginatedApplicationsList() {
+    Application application1 = application(11L);
+    Application application2 = application(12L);
+    Application application3 = application(13L);
+    Application application4 = application(14L);
+    Application application5 = application(15L);
+
+    when(appCenterStorage.getApplications(null)).thenReturn(Arrays.asList(application1, application2, application3, application4, application5));
+
+    ApplicationList applicationsList = applicationCenterService.getApplications(0, 2, null);
+    assertNotNull(applicationsList);
+    assertNotNull(applicationsList.getApplications());
+    assertEquals(2, applicationsList.getApplications().size());
+    assertEquals(5, applicationsList.getSize());
+    assertEquals(0, applicationsList.getOffset());
+    assertEquals(2, applicationsList.getLimit());
+
+    applicationsList = applicationCenterService.getApplications(2, 2, null);
+    assertNotNull(applicationsList);
+    assertNotNull(applicationsList.getApplications());
+    assertEquals(2, applicationsList.getApplications().size());
+    assertEquals(5, applicationsList.getSize());
+    assertEquals(2, applicationsList.getOffset());
+    assertEquals(2, applicationsList.getLimit());
+
+    applicationsList = applicationCenterService.getApplications(4, 2, null);
+    assertNotNull(applicationsList);
+    assertNotNull(applicationsList.getApplications());
+    assertEquals(1, applicationsList.getApplications().size());
+    assertEquals(5, applicationsList.getSize());
+    assertEquals(4, applicationsList.getOffset());
+    assertEquals(2, applicationsList.getLimit());
+
   }
 
   @Test
@@ -374,9 +412,9 @@ public class ApplicationCenterServiceTest {
 
     String keyword1 = "keyword1";
     Application application = application();
+    application.setActive(false);
     when(appCenterStorage.getApplications(keyword1)).thenReturn(Collections.singletonList(application));
 
-    application.setActive(false);
     applicationsList = applicationCenterService.getActiveApplications(0, 0, keyword1, ADMIN_USERNAME);
     assertNotNull(applicationsList);
     assertNotNull(applicationsList.getApplications());


### PR DESCRIPTION
Before this fix, the size returned in the rest service is not correct : it return the size of the current page displayed This commit ensure to return the total size of applications matching the query

Resolved meeds-io/meeds#2394

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
