### PR TITLE
fix: Update default charset and collation for mysql - EXO-75202

### DIFF
--- a/app-center-services/src/main/resources/db.changelogs/app-center-changelog-1.0.0.xml
+++ b/app-center-services/src/main/resources/db.changelogs/app-center-changelog-1.0.0.xml
@@ -33,6 +33,7 @@
   <property name="now" value="CURRENT_TIMESTAMP" dbms="mssql" />
 
   <changeSet author="appCenter" id="1.0.0-1" onValidationFail="MARK_RAN">
+    <validCheckSum>9:4f011443b03e096494c132c5f571647e</validCheckSum>
     <preConditions onFail="MARK_RAN" onError="MARK_RAN">
       <not>
         <tableExists tableName="AC_APPLICATION" />
@@ -73,7 +74,7 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
   
@@ -131,5 +132,11 @@
     <modifyDataType columnName="PERMISSIONS"
                     newDataType="VARCHAR(2000)"
                     tableName="AC_APPLICATION"/>
+  </changeSet>
+
+  <changeSet author="appCenter" id="1.0.0-11" >
+    <sql dbms="mysql">
+      ALTER TABLE AC_FAVORITE_APPLICATION CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+    </sql>
   </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
With mysql 8.4, the default charset and collation are updated from UTF to UTF8MB4. In addition NVARCHAR is now deprecated and replaced by VARCHAR. This commit adapt liquibase changes in order to apply this change.

Resolves Meeds-io/meeds#2564

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
