### PR TITLE
fix: App Center blank display issue - EXO-75399 - Meeds-io/meeds#2600

### DIFF
--- a/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterService.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterService.java
@@ -283,7 +283,10 @@ public class ApplicationCenterService {
                                                      username,
                                                      application.getTitle()));
     }
-    appCenterStorage.addApplicationToUserFavorite(applicationId, username);
+    boolean isFavoriteApplication = appCenterStorage.isFavoriteApplication(applicationId, username);
+    if (!isFavoriteApplication) {
+      appCenterStorage.addApplicationToUserFavorite(applicationId, username);
+    }
   }
 
   /**


### PR DESCRIPTION
Before this change, when open 3 tab of user applications (all apps) and add the app in favorite in your opened tab then refresh the interface, apps aren't available, the added app in favorite is duplicated in My applications drawer and in Favorite applications portlet and apps can't be removable from favorite. To resolve this problem, add a condition before adding this application to the favorites list to check if this application is already a favorite. After this change, the apps could not be duplicated.

(cherry picked from commit 74092ae1170d8d85db6880a4a3b8802027fbd46b)