### PR TITLE
fix: Add/update application having a customized URL isn't saved - EXO-75618 - Meeds-io/meeds#2619

### DIFF
--- a/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterService.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterService.java
@@ -658,7 +658,7 @@ public class ApplicationCenterService {
 
   private boolean isUrlValid(String url) {
     // [-a-zA-Z0-9@:%._\\\\/+~#=] allowed characters
-    String regex = "(http(s)?:\\/\\/.)[-a-zA-Z0-9@:%._\\\\/+~#=?&]{2,256}";
+    String regex = "([a-zA-Z0-9-@:._\\/?&]+:\\/\\/)?http(s)?:\\/\\/[-a-zA-Z0-9@:%._\\\\/+~#=?&]{2,256}";
     Pattern pattern = Pattern.compile(regex);
     return url != null && !url.isBlank()
            && (url.startsWith("/portal/") || url.startsWith("./") || pattern.matcher(url).matches());


### PR DESCRIPTION
Prior to this change, apllications having customized url (not starting by http(s)://) cannot be added or updated This commit fix this by changing the validation regex to support also urls staring by any string then :\\.