### PR TITLE
feat: Delete useless portlet init param - MEED-8372 - Meeds-io/meeds#2924

### DIFF
--- a/app-center-webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/app-center-webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -63,10 +63,6 @@
     <display-name xml:lang="EN">App center user setup portlet</display-name>
     <portlet-class>io.meeds.appcenter.portlet.UserSetupPortlet</portlet-class>
     <init-param>
-      <name>prefetch.resources</name>
-      <value>true</value>
-    </init-param>
-    <init-param>
       <name>prefetch.resource.bundles</name>
       <value>locale.addon.appcenter</value>
     </init-param>


### PR DESCRIPTION
This change will cleanup a removed setting from Portal API.

Resolves Meeds-io/meeds#2924