### PR TITLE
feat: Load App Center Artifact Only When user clicks on Button - MEED-8480 - Meeds-io/meeds#3011

### DIFF
--- a/app-center-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/app-center-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -121,27 +121,6 @@
     </module>
   </portlet>
 
-  <portlet>
-    <name>AppCenterAppLauncherPortlet</name>
-    <module>
-      <depends>
-        <module>vue</module>
-      </depends>
-      <depends>
-        <module>vuetify</module>
-      </depends>
-      <depends>
-        <module>eXoVueI18n</module>
-      </depends>
-      <depends>
-        <module>commonVueComponents</module>
-      </depends>
-      <depends>
-        <module>appLauncherBundle</module>
-      </depends>
-    </module>
-  </portlet>
-
   <module>
     <name>adminSetupPortletBundle</name>
     <script>


### PR DESCRIPTION
Prior to this change, the App Center JS File is loaded as a portlet dependency. This change ensures to not load it only when the user clicks on it App Launcher Icon.

Resolves Meeds-io/meeds#3011