### PR TITLE
fix: Fix Toolbar Auto Grow Style - MEED-8615 - Meeds-io/MIPs#185

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/main/AdminSetupToolbar.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/adminSetup/components/main/AdminSetupToolbar.vue
@@ -27,7 +27,7 @@
       placeholder: $t('appCenter.adminSetupList.filter'),
       tooltip: $t('appCenter.adminSetupList.filter'),
     }"
-    class="border-box-sizing px-1"
+    class="border-box-sizing px-1 flex-grow-0"
     @filter-text-input="$emit('filter-changed', $event)">
     <template v-if="!$root.isMobile" #left>
       <v-btn


### PR DESCRIPTION
Prior to this change, the Admin UI Toolbar component auto grows when the preview content is heigher than apps table height. This change will delete the flex auto grow property on App Center Toolbar.