### PR TITLE
fix: Shortcut Portlet not accessible when using mobile - MEED-8847 - Meeds-io/meeds#3230

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationsList.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationsList.vue
@@ -36,8 +36,10 @@
       v-model="applicationsList"
       :item-key="'id'"
       class="d-flex flex-wrap flex-grow-0 justify-start"
-      @start="onDragStart"
-      @end="onDragEnd">
+      v-bind="isMobile ? {} : {
+        onStart: onDragStart,
+        onEnd: onDragEnd
+      }">
       <my-application-item
         v-for="application in applicationsList"
         :key="application.id"


### PR DESCRIPTION
Prior to this change, the shortcut portlet was not accessible on mobile devices. This issue was caused by drag events being triggered on mobile, even though they are not supported in that context. This change replaces the static event bindings with a conditional v-bind to ensure drag events are only registered when not on mobile.
