### PR TITLE
fix: Remove undefined onDragStart handler - MEED-8847 - Meeds-io/meeds#3230

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationsList.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationsList.vue
@@ -37,7 +37,6 @@
       :item-key="'id'"
       class="d-flex flex-wrap flex-grow-0 justify-start"
       v-bind="isMobile ? {} : {
-        onStart: onDragStart,
         onEnd: onDragEnd
       }">
       <my-application-item


### PR DESCRIPTION
Prior to this change, the draggable component was binding an onStart event handler (onDragStart) that did not exist in the component’s’ methods.
This update removes the unused onDragStart binding.