### PR TITLE
feat: Compute Topbar Pinned Apps switch user permissions - MEED-8883 - Meeds-io/MIPs#185

### DIFF
--- a/app-center-webapps/src/main/webapp/WEB-INF/jsp/appCenter/appLauncher.jsp
+++ b/app-center-webapps/src/main/webapp/WEB-INF/jsp/appCenter/appLauncher.jsp
@@ -1,4 +1,3 @@
-<%@page import="io.meeds.portal.navigation.service.NavigationConfigurationService"%>
 <%@page import="org.apache.commons.lang3.StringUtils"%>
 <%@page import="org.apache.commons.collections4.CollectionUtils"%>
 <%@page import="io.meeds.appcenter.service.ApplicationCenterService"%>
@@ -32,9 +31,6 @@
   SettingService settingService = ExoContainerContext.getService(SettingService.class);
   SettingValue settingValue = settingService.get(Context.USER.id(request.getRemoteUser()), Scope.APPLICATION.id("PinnedApplications"), "pins");
   String pinnedApplicationIds = settingValue == null || settingValue.getValue() == null ? "[]" : settingValue.getValue().toString().replace("\"", "`");
-
-  NavigationConfigurationService navigationConfigurationService = ExoContainerContext.getService(NavigationConfigurationService.class);
-  long topbarAppsCount = navigationConfigurationService.getTopbarConfiguration(request.getRemoteUser(), request.getLocale()).getApplications().stream().filter(a -> a.isEnabled() || a.getId().contains("mandatory-")).count();
 %>
 <div class="VuetifyApp">
   <div
@@ -49,7 +45,7 @@
             title="<%=tooltip%> <%=tooltipShortcut%>"
             class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
             id="appcenterLauncherButton"
-            onclick="Vue.startApp('SHARED/appLauncherBundle', 'init', {isAdmin: <%=isAdmin%>, pinnedApplicationIds: <%=pinnedApplicationIds%>, topbarAppsCount: <%=topbarAppsCount%>})">
+            onclick="Vue.startApp('SHARED/appLauncherBundle', 'init', {isAdmin: <%=isAdmin%>, pinnedApplicationIds: <%=pinnedApplicationIds%>})">
             <span class="v-btn__content">
               <i aria-hidden="true"
                 class="v-icon notranslate appCenterLauncherButtonIcon icon-default-color fa fa-th theme--light"
@@ -58,9 +54,9 @@
           </button>
             <script type="text/javascript">
             <% if (autoInit) { %>
-            window.require(['SHARED/appLauncherBundle'], app => app.init({isAdmin: <%=isAdmin%>, pinnedApplicationIds: <%=pinnedApplicationIds%>, topbarAppsCount: <%=topbarAppsCount%>, autoInitDrawerId: '<%=appCenterDrawer == null ? "" : appCenterDrawer%>', autoInitPortletId: '<%=appCenterPortlet == null ? "" : appCenterPortlet%>'}, true, <%=shortcutListString%>));
+            window.require(['SHARED/appLauncherBundle'], app => app.init({isAdmin: <%=isAdmin%>, pinnedApplicationIds: <%=pinnedApplicationIds%>, autoInitDrawerId: '<%=appCenterDrawer == null ? "" : appCenterDrawer%>', autoInitPortletId: '<%=appCenterPortlet == null ? "" : appCenterPortlet%>'}, true, <%=shortcutListString%>));
             <% } else { %>
-            window.require(['SHARED/commonVueComponents'], () => Vue.prototype.$utils.addShortcutsListener(<%=shortcutListString%>, shortcut => window.require(['SHARED/appLauncherBundle'], app => app.init({isAdmin: <%=isAdmin%>, pinnedApplicationIds: <%=pinnedApplicationIds%>, topbarAppsCount: <%=topbarAppsCount%>}, true, <%=shortcutListString%>, shortcut))));
+            window.require(['SHARED/commonVueComponents'], () => Vue.prototype.$utils.addShortcutsListener(<%=shortcutListString%>, shortcut => window.require(['SHARED/appLauncherBundle'], app => app.init({isAdmin: <%=isAdmin%>, pinnedApplicationIds: <%=pinnedApplicationIds%>}, true, <%=shortcutListString%>, shortcut))));
             <% } %>
             </script>
         </div>

--- a/app-center-webapps/src/main/webapp/vue-apps/application-launcher/components/AppLauncherDrawer.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-launcher/components/AppLauncherDrawer.vue
@@ -251,7 +251,7 @@ export default {
       if (this.$root.isMobile) {
         return this.availablePinnedApplications;
       } else {
-        const recentAppsIndex = Math.max(0, this.maxTopbarApps - this.$root.topbarAppsCount);
+        const recentAppsIndex = Math.max(0, this.maxTopbarApps - eXo.env.portal.topbarAppsCount);
         return recentAppsIndex < this.availablePinnedApplications.length ? this.availablePinnedApplications.slice(recentAppsIndex) : [];
       }
     },

--- a/app-center-webapps/src/main/webapp/vue-apps/application-launcher/main.js
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-launcher/main.js
@@ -25,7 +25,6 @@ let initialized = false;
 export async function init({
   isAdmin,
   pinnedApplicationIds,
-  topbarAppsCount,
   autoInitDrawerId,
   autoInitPortletId
 }, noAutoOpen, shortcuts, shortcut) {
@@ -50,7 +49,6 @@ export async function init({
         pinnedApplicationIds,
         autoInitDrawerId,
         autoInitPortletId,
-        topbarAppsCount,
         canPinApps: !!document.querySelector('#userPinnedApplications'),
         quickActionExtensions: [],
         collator: new Intl.Collator(eXo.env.portal.language, {numeric: true, sensitivity: 'base'}),

--- a/app-center-webapps/src/main/webapp/vue-apps/topbar-pinned-applications/components/UserPinnedApplications.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/topbar-pinned-applications/components/UserPinnedApplications.vue
@@ -67,18 +67,14 @@
 export default {
   data: () => ({
     loading: {},
-    maxTopbarApps: 10,
     openPortletDrawer: false,
   }),
   computed: {
+    pinnedApplications() {
+      return this.$root.pinnedApplications.slice(0, this.$root.limit);
+    },
     hasPinnedApps() {
       return this.pinnedApplications?.length && !this.$root.isMobile;
-    },
-    limit() {
-      return Math.max(0, this.maxTopbarApps - this.$root.topbarAppsCount);
-    },
-    pinnedApplications() {
-      return this.$root.pinnedApplications.slice(0, this.limit);
     },
   },
   methods: {

--- a/app-center-webapps/src/main/webapp/vue-apps/topbar-pinned-applications/main.js
+++ b/app-center-webapps/src/main/webapp/vue-apps/topbar-pinned-applications/main.js
@@ -30,10 +30,15 @@ export async function init(pinnedApplicationIds, topbarAppsCount) {
     vuetify: Vue.prototype.vuetifyOptions,
     i18n,
     data: () => ({
+      resizeObserver: null,
+      maxTopbarApps: 10,
       topbarAppsCount,
       pinnedApplicationIds,
       quickActionExtensions: [],
       applications: null,
+      topbarParentElement: document.querySelector('#middle-topNavigation-container'),
+      topbarMaxWidth: 324,
+      topbarElementWidth: 36,
       collator: new Intl.Collator(eXo.env.portal.language, {numeric: true, sensitivity: 'base'}),
     }),
     computed: {
@@ -50,6 +55,17 @@ export async function init(pinnedApplicationIds, topbarAppsCount) {
           .map(id => this.applications?.find?.(app => app.id === id))
           .filter(app => app);
       },
+      limit() {
+        return Math.max(0, this.maxTopbarApps - this.topbarAppsCount);
+      },
+    },
+    watch: {
+      topbarAppsCount: {
+        immediate: true,
+        handler() {
+          eXo.env.portal.topbarAppsCount = this.topbarAppsCount;
+        },
+      },
     },
     created() {
       document.addEventListener('extension-QuickAction-Extension-updated', this.refreshQuickActions);
@@ -59,12 +75,20 @@ export async function init(pinnedApplicationIds, topbarAppsCount) {
       this.refreshQuickActions();
       this.init();
     },
+    mounted() {
+      this.resizeObserver = new ResizeObserver(this.updateMaxApps).observe(this.topbarParentElement);
+    },
     beforeDestroy() {
       document.removeEventListener('extension-QuickAction-Extension-updated', this.refreshQuickActions);
       document.removeEventListener('app-center-application-unpinned', this.refreshPinnedApplications);
       document.removeEventListener('app-center-application-pinned', this.refreshPinnedApplications);
+      this.resizeObserver?.disconnect?.();
     },
     methods: {
+      updateMaxApps() {
+        const topbarAppsWidth = this.topbarParentElement.offsetWidth - this.$el.offsetWidth;
+        this.topbarAppsCount = parseInt(topbarAppsWidth / this.topbarElementWidth) + 1;
+      },
       async init() {
         if (this.pinnedApplicationIds?.length) {
           const data = await this.$applicationService.getApplications();


### PR DESCRIPTION
Prior to this change, the apps count which are displayed in Topbar isn't fixed to 9 for all users. In fact, the list of applications to display differes switch user privileges. This change ensures to compute the displayed applications count based on UI instead of predetermined number (multiple factors may lead to have different max apps to display in Topbar which makes it difficult to have a deterministic computing method).