### PR TITLE
fix: MyFavorite doesn't display all favorited applications - MEED-8931 - Meeds-io/meeds#3260

### DIFF
--- a/app-center-services/src/main/java/io/meeds/appcenter/dao/ApplicationDAO.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/dao/ApplicationDAO.java
@@ -82,7 +82,7 @@ public interface ApplicationDAO extends JpaRepository<ApplicationEntity, Long> {
       FROM ApplicationEntity app
       LEFT JOIN FavoriteApplicationEntity favoriteApp \
             ON app.id = favoriteApp.application.id AND favoriteApp.userName = :userName
-      WHERE app.active = TRUE AND (favoriteApp.id IS NOT NULL OR app.isMandatory = TRUE)
+      WHERE app.active = TRUE AND (app.isMandatory = TRUE OR favoriteApp.id IS NOT NULL)
       ORDER BY favoriteApp.order NULLS LAST, app.isMandatory DESC
       """)
   Page<FavoriteApplicationEntity> findFavoriteAndMandatoryApplications(@Param("userName") String userName, Pageable pageable);

--- a/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterService.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterService.java
@@ -591,10 +591,9 @@ public class ApplicationCenterService {
                                                      .stream()
                                                      .filter(app -> hasPermission(username, app))
                                                      .collect(Collectors.toList());
-    long countFavorites = appCenterStorage.countFavorites(username);
     int appCount = applications.size();
     return new ApplicationList().setApplications(applications)
-                                .setCanAddFavorite(countFavorites < getMaxFavoriteApps())
+                                .setCanAddFavorite(appCount < getMaxFavoriteApps())
                                 .setLimit(appCount)
                                 .setSize(appCount)
                                 .setOffset(0);

--- a/app-center-services/src/test/java/io/meeds/appcenter/service/ApplicationCenterServiceTest.java
+++ b/app-center-services/src/test/java/io/meeds/appcenter/service/ApplicationCenterServiceTest.java
@@ -502,9 +502,8 @@ public class ApplicationCenterServiceTest {
     assertEquals(4, applicationList.getLimit());
     assertEquals(0, applicationList.getOffset());
 
-    when(appCenterStorage.countFavorites(username)).thenReturn(6L);
     applicationList = applicationCenterService.getMandatoryAndFavoriteApplications(username, pageable);
-    assertFalse(applicationList.isCanAddFavorite());
+    assertTrue(applicationList.isCanAddFavorite());
   }
 
   private Application application() {

--- a/app-center-webapps/src/main/webapp/vue-apps/appLauncher/components/AppLauncherDrawer.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/appLauncher/components/AppLauncherDrawer.vue
@@ -138,6 +138,7 @@ export default {
       draggedElementIndex: null,
       alphabeticalOrder: true,
       appCenterLink: `${eXo.env.portal.context}/${eXo.env.portal.portalName}/appCenterUserSetup/`,
+      maxFavoriteApps: 0
     };
   },
   watch: {
@@ -219,7 +220,7 @@ export default {
       this.$refs.appLauncherDrawer.open();
     },
     getMandatoryAndFavoriteApplications() {
-      return fetch('/app-center/rest/favorites', {
+      return fetch(`/app-center/rest/favorites?size=${this.maxFavoriteApps}`, {
         method: 'GET',
         credentials: 'include',
       })
@@ -318,6 +319,7 @@ export default {
         })
         .then(data => {
           Object.assign(this.defaultAppImage, data && data.defaultApplicationImage);
+          this.maxFavoriteApps = data?.maxFavoriteApps;
         });
     },
     getAppIndex(appList, appId) {

--- a/app-center-webapps/src/main/webapp/vue-apps/userSetup/components/UserAuthorizedApplications.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/userSetup/components/UserAuthorizedApplications.vue
@@ -220,7 +220,6 @@ export default {
       searchText: '',
       searchApp: '',
       searchDelay: 300,
-      maxFavoriteApps: '',
       authorizedApplicationsListMsg: this.$t('appCenter.userSetup.loading')
     };
   },
@@ -246,7 +245,6 @@ export default {
   created() {
     this.isMobileDevice = this.detectMobile();
     Promise.all([
-      this.getMaxFavoriteApps(),
       this.getAuthorizedApplicationsList()
     ]).finally(() => this.$root.$applicationLoaded());
   },
@@ -340,22 +338,6 @@ export default {
     },
     loadNextPage() {
       this.getAuthorizedApplicationsList();
-    },
-    getMaxFavoriteApps() {
-      return fetch('/app-center/rest/settings', {
-        method: 'GET',
-        credentials: 'include',
-      })
-        .then(resp => {
-          if (resp && resp.ok) {
-            return resp.json();
-          } else {
-            throw new Error('Error when getting the general applications list');
-          }
-        })
-        .then(data => {
-          this.maxFavoriteApps = data.maxFavoriteApps;
-        });
     },
     searchAuthorizedApplicationsList() {
       this.authorizedApplicationsList = [];

--- a/app-center-webapps/src/main/webapp/vue-apps/userSetup/components/UserFavoriteApplications.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/userSetup/components/UserFavoriteApplications.vue
@@ -95,7 +95,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <v-icon class="notReached">
           info
         </v-icon>
-        <span>{{ $t("appCenter.userSetup.maxFavoriteApps.not.reached", {0: $parent.$children[0].maxFavoriteApps}) }}</span>
+        <span>{{ $t("appCenter.userSetup.maxFavoriteApps.not.reached", {0: maxFavoriteApps}) }}</span>
       </div>
       <div v-else class="maxFavorite reached">
         <v-icon>
@@ -122,10 +122,12 @@ export default {
       favoriteApplicationsList: [],
       loading: true,
       canAddFavorite: false,
+      maxFavoriteApps: 0
     };
   },
-  created() {
+  async created() {
     this.isMobileDevice = this.detectMobile();
+    this.maxFavoriteApps = await this.getMaxFavoriteApps();
     this.getFavoriteApplicationsList();
   },
   methods: {
@@ -145,7 +147,7 @@ export default {
       });
     },
     getFavoriteApplicationsList() {
-      return fetch('/app-center/rest/favorites', {
+      return fetch(`/app-center/rest/favorites?size=${this.maxFavoriteApps || 0}`, {
         method: 'GET',
         credentials: 'include',
       })
@@ -233,6 +235,25 @@ export default {
     getAppIndex(appList, appId) {
       return appList.findIndex(app => app.id === appId);
     },
+    async getMaxFavoriteApps() {
+      try {
+        const response = await fetch('/app-center/rest/settings', {
+          method: 'GET',
+          credentials: 'include',
+        });
+
+        if (!response.ok) {
+          throw new Error('Error when getting the general applications list');
+        }
+
+        const data = await response.json();
+        return data.maxFavoriteApps;
+      } catch (error) {
+        console.error(error);
+        return null;
+      }
+    }
+
   }
 };
 </script>


### PR DESCRIPTION
Prior to this change, the My Favorite application did not display all favorited applications when more than 20 were added. This issue occurred because the Spring Pageable request defaulted to a page size of 20 when the size parameter was missing or set to zero.
This change ensures that the page size is explicitly set to the maximum number of favorited applications, resolving the issue.
Resolves https://github.com/Meeds-io/meeds/issues/3260