### PR TITLE
fix : MyApplicationPortlet does not display when headerTitle is null - MEED-9170

### DIFF
--- a/app-center-webapps/src/main/webapp/WEB-INF/jsp/appCenter/myApplications.jsp
+++ b/app-center-webapps/src/main/webapp/WEB-INF/jsp/appCenter/myApplications.jsp
@@ -20,6 +20,9 @@
   boolean showHeader = Boolean.parseBoolean(preferences.getValue("showHeader", "true"));
   String headerTitle = CommonsUtils.getService(TranslationService.class).getTranslationLabelOrDefault(objectType,
           applicationId, fieldName, LocaleContextInfoUtils.getUserLocale(request.getRemoteUser()));
+  if (headerTitle == null) {
+    headerTitle="null";
+  }
 %>
 <div class="VuetifyApp">
   <div data-app="true"

--- a/app-center-webapps/src/main/webapp/WEB-INF/jsp/appCenter/myApplications.jsp
+++ b/app-center-webapps/src/main/webapp/WEB-INF/jsp/appCenter/myApplications.jsp
@@ -20,9 +20,6 @@
   boolean showHeader = Boolean.parseBoolean(preferences.getValue("showHeader", "true"));
   String headerTitle = CommonsUtils.getService(TranslationService.class).getTranslationLabelOrDefault(objectType,
           applicationId, fieldName, LocaleContextInfoUtils.getUserLocale(request.getRemoteUser()));
-  if (headerTitle == null) {
-    headerTitle="null";
-  }
 %>
 <div class="VuetifyApp">
   <div data-app="true"
@@ -33,7 +30,7 @@
         applicationId: '<%=applicationId%>',
         maxAppsToList: '<%=maxAppsToList%>',
         showHeader: <%=showHeader%>,
-        headerTitle: '<%=headerTitle%>' !== 'null' ? '<%=StringEscapeUtils.escapeJava(headerTitle).replace("\\\"", "\"").replace("\\\\\"", "\\\"")%>' : null,
+        headerTitle: <%=headerTitle == null ? null : String.format("'%s'", StringEscapeUtils.escapeJava(headerTitle).replace("\\\"", "\"").replace("\\\\\"", "\\\""))%>,
         isAdmin: <%=isAdmin%>,
         saveSettingsUrl: '<%=saveSettingsUrl%>'
       }));


### PR DESCRIPTION
Before this fix, if headerTitle is null, the test '<%=headerTitle%>' !== 'null' return true, and so StringEscapeUtils.escapeJava is called, returning null and generating NPE when calling replace

This commit ensure to set headerTitle to 'null' string, so that the test is correct.

Resolves meeds-io/meeds#3344

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
