### PR TITLE
feat: Allow to access Apps Shortcuts in standalone pages - MEED-9220 - Meeds-io/meeds#3357

### DIFF
--- a/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/ckeditor-configuration.xml
+++ b/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/ckeditor-configuration.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+	This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU Lesser General Public
+	License as published by the Free Software Foundation; either
+	version 3 of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+	Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+	along with this program; if not, write to the Free Software Foundation,
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<configuration
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
+  xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
+
+  <external-component-plugins>
+    <target-component>io.meeds.social.richeditor.RichEditorConfigurationService</target-component>
+      <component-plugin>
+        <name>AppCenterCKEditorConfiguration</name>
+        <set-method>addPlugin</set-method>
+        <type>io.meeds.social.richeditor.RichEditorConfigurationPlugin</type>
+        <init-params>
+          <object-param>
+            <name>BaseCKEditorConfiguration</name>
+            <object type="io.meeds.social.richeditor.RichEditorConfiguration">
+              <field name="instanceType">
+                <string></string>
+              </field>
+              <field name="filePath">
+                <string>war:/conf/app-center/ckeditor/config.js</string>
+              </field>
+            </object>
+          </object-param>
+       </init-params>
+     </component-plugin>
+  </external-component-plugins>
+
+</configuration>

--- a/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/ckeditor/config.js
+++ b/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/ckeditor/config.js
@@ -1,0 +1,15 @@
+﻿const origEditorConfigFn = CKEDITOR.editorConfig;
+CKEDITOR.editorConfig = function (config) {
+  origEditorConfigFn(config);
+  CKEDITOR.on('instanceReady', function(e) {
+    e.editor.on('key', function(event) {
+      if (event?.data?.domEvent?.$?.ctrlKey && event?.data?.domEvent?.$?.shiftKey) {
+        if (!e.editor.editable().isInline() && window.parent) {
+          window.parent.dispatchEvent(new CustomEvent('key-down', {detail: {
+            key: event.data.domEvent.$.key,
+          }}));
+        }
+      }
+    });
+  }); 
+};

--- a/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/portal-configuration.xml
+++ b/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/portal-configuration.xml
@@ -107,6 +107,53 @@
         </object-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>addPlugin</name>
+      <set-method>addPlugin</set-method>
+      <type>org.exoplatform.commons.addons.AddOnPluginImpl</type>
+      <description></description>
+      <init-params>
+        <value-param>
+          <name>priority</name>
+          <value>1</value>
+        </value-param>
+        <value-param>
+          <name>containerName</name>
+          <value>body-end-container</value>
+        </value-param>
+        <object-param>
+          <name>appcenter-shortcuts-portlet</name>
+          <description></description>
+          <object type="org.exoplatform.commons.addons.PortletModel">
+            <field name="contentId">
+              <string>app-center/AppCenterAppShortcutsPortlet</string>
+            </field>
+            <field name="permissions">
+              <collection type="java.util.ArrayList">
+                <value>
+                  <string>*:/platform/users</string>
+                </value>
+                <value>
+                  <string>*:/platform/externals</string>
+                </value>
+              </collection>
+            </field>
+            <field name="title">
+              <string>Appcenter shortcuts</string>
+            </field>
+            <field name="showInfoBar">
+              <boolean>false</boolean>
+            </field>
+            <field name="showApplicationState">
+              <boolean>false</boolean>
+            </field>
+            <field name="showApplicationMode">
+              <boolean>false</boolean>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
 </configuration>

--- a/app-center-webapps/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/app-center-webapps/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -27,4 +27,5 @@
   <import>war:/conf/app-center/portal-configuration.xml</import>
   <import>war:/conf/app-center/bundle-configuration.xml</import>
   <import>war:/conf/app-center/search-configuration.xml</import>
+  <import>war:/conf/app-center/ckeditor-configuration.xml</import>
 </configuration>

--- a/app-center-webapps/src/main/webapp/WEB-INF/jsp/appCenter/appShortcuts.jsp
+++ b/app-center-webapps/src/main/webapp/WEB-INF/jsp/appCenter/appShortcuts.jsp
@@ -13,15 +13,12 @@
 <%@page import="org.exoplatform.commons.api.settings.data.Scope"%>
 <%@page import="org.exoplatform.commons.api.settings.data.Context"%>
 <%
-  ResourceBundle bundle;
-  try {
-    bundle = ExoContainerContext.getService(ResourceBundleService.class).getResourceBundle("locale.addon.appcenter", request.getLocale());
-  } catch (Exception e) {
-    bundle = ExoContainerContext.getService(ResourceBundleService.class).getResourceBundle("locale.addon.appcenter", Locale.ENGLISH);
-  }
-  String tooltip = bundle.getString("appCenter.appLauncher.topbarIcon.tooltip");
-  String tooltipShortcut = bundle.getString("appCenter.appLauncher.topbarIcon.tooltip.shortcut");
   boolean isAdmin = ConversationState.getCurrent().getIdentity().isMemberOf("/platform/administrators");
+  String appCenterDrawer = PortalRequestContext.getCurrentInstance().getRequest().getParameter("appCenterDrawer");
+  String appCenterPortlet = PortalRequestContext.getCurrentInstance().getRequest().getParameter("appCenterPortlet");
+  boolean autoInit = appCenterDrawer != null || appCenterPortlet != null;
+  List<String> shortcuts = ExoContainerContext.getService(ApplicationCenterService.class).getApplicationShortcuts(PortalRequestContext.getCurrentInstance().getRemoteUser());
+  String shortcutListString = CollectionUtils.isEmpty(shortcuts) ? "['a']" : String.format("['%s','a']", StringUtils.join(shortcuts, "', '"));
 
   SettingService settingService = ExoContainerContext.getService(SettingService.class);
   SettingValue settingValue = settingService.get(Context.USER.id(request.getRemoteUser()), Scope.APPLICATION.id("PinnedApplications"), "pins");
@@ -31,22 +28,17 @@
   <div
     data-app="true"
     class="v-application v-application--is-ltr theme--light"
-    id="appLauncher">
+    id="appShortcuts">
     <div class="v-application--wrap">
       <div class="container px-0 py-0">
         <div class="layout transparent">
-          <button
-            type="button"
-            title="<%=tooltip%> <%=tooltipShortcut%>"
-            class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
-            id="appcenterLauncherButton"
-            onclick="Vue.startApp('SHARED/appLauncherBundle', 'init', {isAdmin: <%=isAdmin%>, pinnedApplicationIds: <%=pinnedApplicationIds%>})">
-            <span class="v-btn__content">
-              <i aria-hidden="true"
-                class="v-icon notranslate appCenterLauncherButtonIcon icon-default-color fa fa-th theme--light"
-                style="font-size: 20px;"></i>
-            </span>
-          </button>
+          <script type="text/javascript">
+          <% if (autoInit) { %>
+          window.require(['SHARED/appLauncherBundle'], app => app.init({isAdmin: <%=isAdmin%>, pinnedApplicationIds: <%=pinnedApplicationIds%>, autoInitDrawerId: '<%=appCenterDrawer == null ? "" : appCenterDrawer.replace("'", "&#x27;")%>', autoInitPortletId: '<%=appCenterPortlet == null ? "" : appCenterPortlet.replace("'", "&#x27;")%>'}, true, <%=shortcutListString%>));
+          <% } else { %>
+          window.require(['SHARED/commonVueComponents'], () => Vue.prototype.$utils.addShortcutsListener(<%=shortcutListString%>, shortcut => window.require(['SHARED/appLauncherBundle'], app => app.init({isAdmin: <%=isAdmin%>, pinnedApplicationIds: <%=pinnedApplicationIds%>}, true, <%=shortcutListString%>, shortcut))));
+          <% } %>
+          </script>
         </div>
       </div>
     </div>

--- a/app-center-webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/app-center-webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -109,6 +109,28 @@
     </portlet-info>
   </portlet>
   <portlet>
+    <portlet-name>AppCenterAppShortcutsPortlet</portlet-name>
+    <display-name xml:lang="EN">App center app launcher portlet</display-name>
+    <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>
+    <init-param>
+      <name>portlet-view-dispatched-file-path</name>
+      <value>/WEB-INF/jsp/appCenter/appShortcuts.jsp</value>
+    </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
+    </init-param>
+    <supports>
+      <mime-type>text/html</mime-type>
+    </supports>
+    <supported-locale>en</supported-locale>
+    <resource-bundle>locale.addon.appcenter</resource-bundle>
+    <portlet-info>
+      <title>App center app shortcuts portlet</title>
+      <keywords>App center shortcuts</keywords>
+    </portlet-info>
+  </portlet>
+  <portlet>
     <portlet-name>UserPinnedApplications</portlet-name>
     <display-name xml:lang="EN">User Pinned Applications</display-name>
     <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>

--- a/app-center-webapps/src/main/webapp/vue-apps/application-launcher/components/AppLauncher.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-launcher/components/AppLauncher.vue
@@ -19,7 +19,7 @@
 -->
 <template>
   <v-app flat>
-    <v-container px-0 py-0>
+    <v-container v-if="!$root.hideApp" px-0 py-0>
       <v-layout class="transparent">
         <v-btn
           id="appcenterLauncherButton"

--- a/app-center-webapps/src/main/webapp/vue-apps/application-launcher/main.js
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-launcher/main.js
@@ -26,12 +26,18 @@ export async function init({
   isAdmin,
   pinnedApplicationIds,
   autoInitDrawerId,
-  autoInitPortletId
+  autoInitPortletId,
 }, noAutoOpen, shortcuts, shortcut) {
   if (initialized) {
     return;
   }
   initialized = true;
+  let appElement = document.querySelector(`#${appId}`);
+  const hideApp = !appElement;
+  if (!appElement) {
+    appElement = document.querySelector('#appShortcuts');
+  }
+
   const lang = eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || 'en';
   const urls = [
     `/app-center/i18n/locale.addon.appcenter?lang=${lang}`,
@@ -44,6 +50,7 @@ export async function init({
       data: () => ({
         isAdmin,
         noAutoOpen,
+        hideApp,
         shortcut,
         shortcuts: shortcuts?.filter?.(c => c?.length)?.map?.(c => c.toLowerCase()) || [],
         pinnedApplicationIds,
@@ -86,7 +93,7 @@ export async function init({
       template: `<app-center-launcher id="${appId}" />`,
       vuetify: Vue.prototype.vuetifyOptions,
       i18n: i18n,
-    }, `#${appId}`, 'Application Center Drawer');
+    }, appElement, 'Application Center Drawer');
   } finally {
     Vue.prototype.$utils.includeExtensions('QuickActionExtension');
   }


### PR DESCRIPTION
This change will make it possible to access App Center Shortcuts even in Standalone pages where the App Launcher isn't displayed. In addition, this will allow to propagate the keyboard event from CKEditor IFrame to parent window in order to allow to invoke the shortcut app even when the CKEDitor Iframe is focused.

Resolves Meeds-io/meeds#3357