### PR TITLE
feat: Replace Target Default Site to Meta Site instead of Current one - MEED-9240 - Meeds-io/meeds#3376

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
@@ -268,7 +268,7 @@ export default {
     computedUrl() {
       if (this.application.type === 'LINK') {
         const computedUrl = this.application.url
-          .replace(/^\.\//, `${eXo.env.portal.context}/${eXo.env.portal.portalName}/`)
+          .replace(/^\.\//, `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/`)
           .replace('@user@', eXo.env.portal.userName);
         return this.$utils.toLinkUrl(computedUrl, {
           urls: true,

--- a/app-center-webapps/src/main/webapp/vue-apps/application-launcher/components/AppLauncher.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-launcher/components/AppLauncher.vue
@@ -103,7 +103,7 @@ export default {
       const application = this.applications.find(a => a.shortcut && a.shortcut.toLowerCase() === shortcut.toLowerCase());
       if (application?.type === 'LINK') {
         const computedUrl = application.url
-          .replace(/^\.\//, `${eXo.env.portal.context}/${eXo.env.portal.portalName}/`)
+          .replace(/^\.\//, `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/`)
           .replace('@user@', eXo.env.portal.userName);
         const url = this.$utils.toLinkUrl(computedUrl, {
           urls: true,

--- a/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/MyApplicationsApp.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/MyApplicationsApp.vue
@@ -58,7 +58,6 @@ export default {
       applicationsOrder: {},
       isLoading: false,
       alphabeticalOrder: true,
-      baseUrl: `${eXo.env.portal.context}/${eXo.env.portal.portalName}/`,
       currentUser: eXo.env.portal.userName,
       initialized: false,
     };
@@ -141,7 +140,7 @@ export default {
     },
     computeApplicationUrl(app) {
       if (app.type === 'LINK') {
-        let computedUrl = app.url.replace(/^\.\//, `${eXo.env.portal.context}/${eXo.env.portal.portalName}/`);
+        let computedUrl = app.url.replace(/^\.\//, `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/`);
         computedUrl = computedUrl.replace('@user@', eXo.env.portal.userName);
         computedUrl = this.$utils.toLinkUrl(computedUrl, {
           urls: true,

--- a/app-center-webapps/src/main/webapp/vue-apps/topbar-application/components/TopbarApplication.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/topbar-application/components/TopbarApplication.vue
@@ -77,7 +77,7 @@ export default {
     computedUrl() {
       if (this.application?.type === 'LINK') {
         const computedUrl = this.application.url
-          .replace(/^\.\//, `${eXo.env.portal.context}/${eXo.env.portal.portalName}/`)
+          .replace(/^\.\//, `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/`)
           .replace('@user@', eXo.env.portal.userName);
         return this.$utils.toLinkUrl(computedUrl, {
           urls: true,

--- a/app-center-webapps/src/main/webapp/vue-apps/topbar-pinned-applications/main.js
+++ b/app-center-webapps/src/main/webapp/vue-apps/topbar-pinned-applications/main.js
@@ -105,7 +105,7 @@ export async function init(pinnedApplicationIds, topbarAppsCount) {
             }
             if (app.type === 'LINK' && app.url) {
               const computedUrl = app.url
-                .replace(/^\.\//, `${eXo.env.portal.context}/${eXo.env.portal.portalName}/`)
+                .replace(/^\.\//, `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/`)
                 .replace('@user@', eXo.env.portal.userName);
               app.computedUrl = this.$utils.toLinkUrl(computedUrl, {
                 urls: true,


### PR DESCRIPTION
Prior to this change, the App Center URLs with './' at the begining of its URL are replaced by '/portal/CURRENT_SITE/'. This change will ensure to replace it with '/portal/META_SITE' in order to retrieve all time the shared layout.