### PR TITLE
fix: Avoid declaring a const in CKEditor configuration - MEED-9279 - Meeds-io/meeds#3396

### DIFF
--- a/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/ckeditor/config.js
+++ b/app-center-webapps/src/main/webapp/WEB-INF/conf/app-center/ckeditor/config.js
@@ -1,6 +1,6 @@
-﻿const origEditorConfigFn = CKEDITOR.editorConfig;
+﻿window.origEditorConfigFn = CKEDITOR.editorConfig;
 CKEDITOR.editorConfig = function (config) {
-  origEditorConfigFn(config);
+  window.origEditorConfigFn(config);
   CKEDITOR.on('instanceReady', function(e) {
     e.editor.on('key', function(event) {
       if (event?.data?.domEvent?.$?.ctrlKey && event?.data?.domEvent?.$?.shiftKey) {


### PR DESCRIPTION
Prior to this change, the App Center Quick Actions CKEditor Plugin may be loaded twice which may cause a JS error when the same constant is defined twice in the same JS context. This change will change the constant declaration to a global window variable in order to avoid such a JS error.

Resolves Meeds-io/meeds#3396