### PR TITLE
fix: Update the shortcut for opening notif center - MEED-9284 - Meeds-io/meeds#3404

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/application-user-settings/components/AppCenterUserSettingsWindow.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-user-settings/components/AppCenterUserSettingsWindow.vue
@@ -125,7 +125,7 @@ export default {
       apps.push({
         title: this.$t('appCenter.system.application.notifications'),
         icon: 'fa-bell',
-        shortcut: 'r',
+        shortcut: 'e',
       });
       apps.push({
         title: this.$t('appCenter.system.application.appcenter'),


### PR DESCRIPTION
After updating the display of the shortcut used to open the notification drawer to `Ctrl + Shift + e`, this change will update the shortcut in the user settings window as well.

Resolves  Meeds-io/meeds#3404