### PR TITLE
feat: Improve TranslationService API with Object Id of Type String - MEED-9632 - Meeds-io/meeds#3608

### DIFF
--- a/app-center-services/src/main/java/io/meeds/appcenter/plugin/ApplicationTranslationPlugin.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/plugin/ApplicationTranslationPlugin.java
@@ -49,22 +49,22 @@ public class ApplicationTranslationPlugin extends TranslationPlugin {
   }
 
   @Override
-  public boolean hasAccessPermission(long applicationId, String username) {
+  public boolean hasAccessPermission(String applicationId, String username) {
     return true;
   }
 
   @Override
-  public boolean hasEditPermission(long applicationId, String username) {
+  public boolean hasEditPermission(String applicationId, String username) {
     return applicationCenterService.canEdit(username);
   }
 
   @Override
-  public long getAudienceId(long objectId) {
+  public long getAudienceId(String applicationId) {
     return 0;
   }
 
   @Override
-  public long getSpaceId(long objectId) {
+  public long getSpaceId(String applicationId) {
     return 0;
   }
 }

--- a/app-center-services/src/main/java/io/meeds/appcenter/plugin/MyApplicationsHeaderTranslationPlugin.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/plugin/MyApplicationsHeaderTranslationPlugin.java
@@ -49,22 +49,22 @@ public class MyApplicationsHeaderTranslationPlugin extends TranslationPlugin {
   }
 
   @Override
-  public boolean hasAccessPermission(long objectId, String username) {
+  public boolean hasAccessPermission(String objectId, String username) {
     return true;
   }
 
   @Override
-  public boolean hasEditPermission(long objectId, String username) {
+  public boolean hasEditPermission(String objectId, String username) {
     return applicationCenterService.canEdit(username);
   }
 
   @Override
-  public long getAudienceId(long objectId) {
+  public long getAudienceId(String objectId) {
     return 0;
   }
 
   @Override
-  public long getSpaceId(long objectId) {
+  public long getSpaceId(String objectId) {
     return 0;
   }
 }

--- a/app-center-services/src/test/java/io/meeds/appcenter/plugin/ApplicationTranslationPluginTest.java
+++ b/app-center-services/src/test/java/io/meeds/appcenter/plugin/ApplicationTranslationPluginTest.java
@@ -41,7 +41,7 @@ public class ApplicationTranslationPluginTest {
 
   private static final String          TEST_USER = "testuser";
 
-  private static final long            APP_ID    = 15l;
+  private static final String          APP_ID    = "15";
 
   @MockBean
   private TranslationService           translationService;

--- a/app-center-services/src/test/java/io/meeds/appcenter/plugin/MyApplicationsHeaderTranslationPluginTest.java
+++ b/app-center-services/src/test/java/io/meeds/appcenter/plugin/MyApplicationsHeaderTranslationPluginTest.java
@@ -63,24 +63,24 @@ public class MyApplicationsHeaderTranslationPluginTest {
 
   @Test
   void hasEditPermission() {
-    assertFalse(translationPlugin.hasEditPermission(15l, TEST_USER));
+    assertFalse(translationPlugin.hasEditPermission("15", TEST_USER));
     when(applicationCenterService.canEdit(TEST_USER)).thenReturn(true);
-    assertTrue(translationPlugin.hasEditPermission(15l, TEST_USER));
+    assertTrue(translationPlugin.hasEditPermission("15", TEST_USER));
   }
 
   @Test
   void hasAccessPermission() {
-    assertTrue(translationPlugin.hasAccessPermission(15l, TEST_USER));
+    assertTrue(translationPlugin.hasAccessPermission("15", TEST_USER));
   }
 
   @Test
   void getAudienceId() {
-    assertEquals(0l, translationPlugin.getAudienceId(15l));
+    assertEquals(0l, translationPlugin.getAudienceId("15"));
   }
 
   @Test
   void getSpaceId() {
-    assertEquals(0l, translationPlugin.getSpaceId(15l));
+    assertEquals(0l, translationPlugin.getSpaceId("15"));
   }
 
 }


### PR DESCRIPTION
This change will enhance `TranslationService` by accepting the `objectId` of type `String` in addition to type `Long`.

Resolves Meeds-io/meeds#3608