### PR TITLE
Fix: Application doesn't receive focus - MEED-9926 - meeds-io/meeds#3821.

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
@@ -46,6 +46,7 @@
       :title="titleTooltip"
       class="appLauncherItemContainer fill-height d-flex flex-column align-center justify-center"
       tabindex="0"
+      @keydown.space.stop="$emit('toogle-pin', !pinnedApplication)"
       @keydown.enter="openApp"
       @focusin="hover = true"
       @focusout="onFocusOut">
@@ -152,7 +153,6 @@
           <app-center-shortcut
             v-if="application.shortcut && !$root.isMobile && hover"
             :shortcut="application.shortcut"
-            tabindex="0"
             class="align-self-md-center align-self-end mb-2 mb-md-0" />
           <v-spacer />  
           <v-btn


### PR DESCRIPTION
Before this change, when accessing the App Center in compact and extended mode and then browsing applications by tabbing, the applications did not receive focus, and the pin button did not appear on each application. To fix this problem, add a click event for the button allowing the Space key to pin the application. After this change, tabbing and clicking the Space and Enter keys work correctly.
