### PR TITLE
fix: Display the see all buttons when focusing - MEED-9939 - Meeds-io/meeds#3831

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/MyApplicationsApp.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/MyApplicationsApp.vue
@@ -26,12 +26,13 @@
         extra-class="application-body position-static border-box-sizing">
         <my-applications-toolbar
           v-if="!isLoading"
-          :hover="hover"
+          :hover="hover || focused"
           :is-admin="isAdmin"
           :show-header="showHeader"
           :header-title="headerTitle"
           :has-applications="hasApplications"
-          @open-settings="openSettingsDrawer" />
+          @open-settings="openSettingsDrawer"
+          @focus="handleFocus" />
         <my-applications-list
           :applications-list="filteredApplications"
           :is-loading="isLoading"
@@ -60,6 +61,7 @@ export default {
       alphabeticalOrder: true,
       currentUser: eXo.env.portal.userName,
       initialized: false,
+      focused: false
     };
   },
   computed: {
@@ -187,6 +189,9 @@ export default {
         return;
       }
       this.updateApplicationsOrder(applicationList);
+    },
+    handleFocus() {
+      this.focused = true;
     },
   }
 };

--- a/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationsToolbar.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationsToolbar.vue
@@ -37,7 +37,8 @@
           small
           text
           link
-          @click="openApplications('seeMore')">
+          @click="openApplications('seeMore')"
+          @focus="$emit('focus')">
           <span class="primary--text text-none">
             {{ $t('myApplications.seeMore.label') }}
           </span>


### PR DESCRIPTION
Prior to this change, when focusing on "see all" button, the "See all" and "Edit settings" buttons don't appear as per hover. This change will adjust this bahavior.