### PR TITLE
fix: Some informations disappear when disabling the style - MEED-9924 - meeds-io/meeds#3819.

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
@@ -157,14 +157,13 @@
           <v-spacer />  
           <v-btn
             v-if="application.helpPageURL"
-            :href="application.helpPageURL"
             :title="$t('appCenter.appLauncher.accessHelpPageTooltip')"
             :class="card && 'ms-2'"
             small
             icon
             mouseup.stop="0"
             mousedown.stop="0"
-            click.stop="0">
+            @click.stop="openHelpPageURL(application.helpPageURL)">
             <v-icon
               :color="!card && 'white'"
               :size="card && 20 || 16">
@@ -331,6 +330,9 @@ export default {
       if (!this.$el.contains(event.relatedTarget)) {
         this.hover = false;
       }
+    },
+    openHelpPageURL(helpPageURL) {
+      window.open(helpPageURL, '_blank', 'noopener');
     }
   },
 };


### PR DESCRIPTION
before this change, when access to App center in extended mode then disable the style, the help buttons (if exist) disappear. To fix this problem, changer le href par l'event de click du bouton. After this change, help button still exist even when disabling the style.