### PR TITLE
fix: Application doesn't receive focus - MEED-9926 - meeds-io/meeds#3821.

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
@@ -304,9 +304,11 @@ export default {
     },
   },
   methods: {
-    openApp() {
-      this.addToRecent();
-      this.$emit('open');
+    openApp(event) {
+      if (document.activeElement === event.currentTarget) {
+        this.addToRecent();
+        this.$emit('open');
+      }
     },
     addToRecent() {
       if (this.readonly) {


### PR DESCRIPTION
Before this change, when accessing the App Center in compact and extended mode and then browsing applications by tabbing, the applications did not receive focus, and the pin button did not appear on each application. To fix this problem, add a click event for the button allowing the Space key to pin the application. After this change, tabbing and clicking the Space and Enter keys work correctly.