### PR TITLE
fix: Application doesn't receive focus - MEED-9926 - meeds-io/meeds#3821.

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
@@ -39,6 +39,7 @@
         $attrs.class,
         {
           'border-color': card,
+          'border-color-black': isFocused,
           'transparent': !card && !hover,
           'light-grey-background-color': !card && hover,
         }
@@ -49,7 +50,7 @@
       tabindex="0"
       @keydown.space.stop="$emit('toogle-pin', !pinnedApplication)"
       @keydown.enter="openApp"
-      @focusin="hover = true"
+      @focusin="onFocusIn"
       @focusout="onFocusOut">
       <v-progress-linear
         v-if="loading"
@@ -273,6 +274,7 @@ export default {
   },
   data: () => ({
     hover: false,
+    isFocused: false,
   }),
   computed: {
     computedUrl() {
@@ -349,7 +351,12 @@ export default {
     onFocusOut(event) {
       if (!this.$el.contains(event.relatedTarget)) {
         this.hover = false;
+        this.isFocused = false;
       }
+    },
+    onFocusIn() {
+      this.isFocused = true;
+      this.hover = true;
     },
     openHelpPageURL(helpPageURL) {
       window.open(helpPageURL, '_blank', 'noopener');


### PR DESCRIPTION
Before this change, when accessing the App Center in compact and extended mode and then browsing applications by tabbing, the applications did not receive focus, and the pin button did not appear on each application. To fix this problem, add a click event for the button allowing the Space key to pin the application. After this change, tabbing and clicking the Space and Enter keys work correctly.