### PR TITLE
fix: Pinned applications are distinguished only by their shape - MEED-9927 - meeds-io/meeds#3822.

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
@@ -176,6 +176,7 @@
               class="ms-2"
               small
               icon
+              :aria-pressed="pinnedApplication ? 'true' : 'false'"
               mouseup.stop="0"
               mousedown.stop="0"
               @click.stop.prevent="$emit('toogle-pin', !pinnedApplication)">


### PR DESCRIPTION
Before this change, when access to App center in extended mode and pin an application, the pinned application is distinguished only by the button shape. To fix this problem, add the aria-pressed attribute to the pin button. After this change, aria-pressed is true when the application is pinned and aria-pressed is false when the application isn't pinned.