### PR TITLE
fix: Display the see all buttons when focusing - MEED-9939 - Meeds-io/meeds#3831

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/MyApplicationsApp.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/MyApplicationsApp.vue
@@ -32,7 +32,8 @@
           :header-title="headerTitle"
           :has-applications="hasApplications"
           @open-settings="openSettingsDrawer"
-          @focus="handleFocus" />
+          @focus="handleFocus"
+          @blur="handleBlur" />
         <my-applications-list
           :applications-list="filteredApplications"
           :is-loading="isLoading"
@@ -192,6 +193,9 @@ export default {
     },
     handleFocus() {
       this.focused = true;
+    },
+    handleBlur() {
+      this.focused = false;
     },
   }
 };

--- a/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationsToolbar.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationsToolbar.vue
@@ -38,7 +38,7 @@
           text
           link
           @click="openApplications('seeMore')"
-          @focus="$emit('focus')">
+          @focusin="$emit('focus')">
           <span class="primary--text text-none">
             {{ $t('myApplications.seeMore.label') }}
           </span>
@@ -56,7 +56,8 @@
               small
               link
               icon
-              @click="openApplications('seeMoreIcon')">
+              @click="openApplications('seeMoreIcon')"
+              @keydown.tab.stop="onShiftTabPress">
               <v-icon
                 :size="18"
                 class="icon-default-size">
@@ -78,6 +79,7 @@
             small
             link
             icon
+            @keydown.tab.stop="onTabPress"
             @click="$emit('open-settings')">
             <v-icon
               :size="18"
@@ -168,6 +170,16 @@ export default {
         .then(() => this.$refs.applicationsDrawer.open())
         .finally(() => this.loading = null);
     },
+    onShiftTabPress(event) {
+      if (event.shiftKey) {
+        this.$emit('blur');
+      }
+    },
+    onTabPress(event) {
+      if (event.key === 'Tab' && !event.shiftKey) {
+        this.$emit('blur');
+      }
+    }
   },
 };
 </script>


### PR DESCRIPTION
Prior to this change, , in my applications portlet, when navigating with the Tab key, the two buttons also appear, but the “See all” text doesn't appear again after tabbing out of MyApplication and even when hovering (it appears again only after refresh). This change will fix this issue.