### PR TITLE
fix: Fix applications images to be decorative - MEED-9933 - meeds-io/meeds#3834

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationItem.vue
@@ -45,7 +45,6 @@
         <v-img
           v-if="application.imageUrl"
           :src="application.imageUrl"
-          :alt="applicationTitle"
           referrerpolicy="no-referrer"
           class="mx-auto"
           max-width="45"
@@ -59,7 +58,6 @@
         </v-icon>
         <v-img
           v-else
-          :alt="applicationTitle"
           src="/app-center/skin/images/defaultApp.png"
           max-width="45"
           max-height="45"


### PR DESCRIPTION
This change will remove the role and the aria label attributes generated by v-img component.

Resolves: Meeds-io/meeds#3834
