### PR TITLE
fix: Use p tag for application's description - MEED-9921 - Meeds-io/meeds#3815

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
@@ -142,13 +142,13 @@
         <div v-if="!card" class="text-truncate white--text">
           {{ application.title }}
         </div>
-        <div
+        <p
           :class="{
             'text-font-small-size white--text': !card,
           }"
           class="text-truncate-3">
           {{ application.description }}
-        </div>
+        </p>
         <div 
           class="d-flex align-center mt-auto mb-1 flex-wrap justify-space-between overflow-hidden border-box-sizing"
           role="group">


### PR DESCRIPTION
This change will use p tag instead of div tag for application's description.