### PR TITLE
fix: Use p tag for application's description - MEED-9921 - Meeds-io/meeds#3815

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
@@ -135,13 +135,13 @@
         <div v-if="!card" class="text-truncate white--text">
           {{ application.title }}
         </div>
-        <div
+        <p
           :class="{
             'text-font-small-size white--text': !card,
           }"
           class="text-truncate-4">
           {{ application.description }}
-        </div>
+        </p>
         <div class="d-flex align-center mt-auto mb-1">
           <app-center-shortcut
             v-if="application.shortcut && !$root.isMobile && hover"


### PR DESCRIPTION
This change will use p tag instead of div tag for application's description.

Resolves: Meeds-io/meeds#3815
