### PR TITLE
fix: Ensure to correctly load the application image - MEED-9987 - meeds-io/meeds#3874

### DIFF
--- a/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterInjectService.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterInjectService.java
@@ -34,6 +34,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import lombok.SneakyThrows;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -255,11 +257,11 @@ public class ApplicationCenterInjectService {
         if (resource == null) {
           LOG.warn("Application Image with path {} doesn't exist", imagePath);
         } else {
-          File file = new File(resource.getFile());
+          File file = createTempFile(configurationManager.getInputStream(imagePath).readAllBytes());
           UploadResource uploadResource = new UploadResource(uploadId,
                                                              file.getName(),
                                                              "image/png",
-                                                             file.getAbsolutePath(),
+                                                             file.getPath(),
                                                              0,
                                                              0,
                                                              UploadResource.UPLOADED_STATUS);
@@ -327,5 +329,16 @@ public class ApplicationCenterInjectService {
                        APP_CENTER_SYSTEM_APP_KEY,
                        SettingValue.create(APP_CENTER_APPS_VERSION));
   }
+
+  @SneakyThrows
+  private File createTempFile(byte[] data) {
+    if (data == null) {
+      throw new IllegalArgumentException("Illustration data is null");
+    }
+    File tempFile = new File(System.getProperty("java.io.tmpdir") + File.separator + "temp.png");
+    FileUtils.writeByteArrayToFile(tempFile, data);
+    return tempFile;
+  }
+
 
 }

--- a/app-center-services/src/test/java/io/meeds/appcenter/service/ApplicationCenterInjectServiceTest.java
+++ b/app-center-services/src/test/java/io/meeds/appcenter/service/ApplicationCenterInjectServiceTest.java
@@ -94,6 +94,17 @@ public class ApplicationCenterInjectServiceTest {
     applicationCenterInjectService.injectDefaultApplications();
     assertTrue(applicationCenterInjectService.getDefaultApplications().size() >= 1);
 
+
+    Application application0 = application();
+    application0.setTitle("");
+    ApplicationDescriptor applicationPlugin0 = new ApplicationDescriptor(null, application0);
+    applicationPlugin0.setName("testapp0");
+    applicationPlugin0.setEnabled(true);
+    applicationCenterInjectService.addApplicationPlugin(applicationPlugin0);
+    applicationCenterInjectService.injectDefaultApplications();
+    verify(applicationCenterService,
+           never()).createApplication(argThat(app -> app.getTitle().equals("")));
+
     String pluginName = "testapp";
 
     Application application = application();


### PR DESCRIPTION
Before this fix, when the unpack war is set to false, application center images are not correctly read This is because the image is inside the war when unpack_war is set to false. This commit ensure to read the image as resource, to be sure to read it correctly.

Resolves meeds-io/meeds#3874

(cherry picked from commit 36de1bbb94a928c2e0dc23c4f86d72bd4097163b)