### PR TITLE
fix: Display the see all buttons when focusing - MEED-9939 - Meeds-io/meeds#3831

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/MyApplicationsApp.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/MyApplicationsApp.vue
@@ -20,20 +20,23 @@
 
 <template>
   <v-app id="myApplications">
-    <v-hover v-slot="{hover}">
+    <v-hover v-model="hover">
       <widget-wrapper
+        ref="widget"
         :loading="isLoading"
-        extra-class="application-body position-static border-box-sizing">
+        :tabindex="tabindex"
+        extra-class="application-body position-static border-box-sizing"
+        @focusin="onFocusIn" 
+        @focusout="onFocusOut">
         <my-applications-toolbar
           v-if="!isLoading"
-          :hover="hover || focused"
+          ref="myApplicationsToolbar"
+          :hover="hover"
           :is-admin="isAdmin"
           :show-header="showHeader"
           :header-title="headerTitle"
           :has-applications="hasApplications"
-          @open-settings="openSettingsDrawer"
-          @focus="handleFocus"
-          @blur="handleBlur" />
+          @open-settings="openSettingsDrawer" />
         <my-applications-list
           :applications-list="filteredApplications"
           :is-loading="isLoading"
@@ -62,7 +65,8 @@ export default {
       alphabeticalOrder: true,
       currentUser: eXo.env.portal.userName,
       initialized: false,
-      focused: false
+      hover: false,
+      tabindex: '0'
     };
   },
   computed: {
@@ -191,11 +195,27 @@ export default {
       }
       this.updateApplicationsOrder(applicationList);
     },
-    handleFocus() {
-      this.focused = true;
+    onFocusIn(event) {
+      this.hover =true;
+      this.$nextTick(() => {
+        const activeElement = document.activeElement;
+        const header = this.$refs.myApplicationsToolbar?.$refs?.btnSeeMoreIcon?.$el;
+        if (header && activeElement === this.$refs.widget?.$el && event.relatedTarget) {
+          header.focus();
+        }
+        if (this.tabindex === '0') {
+          this.tabindex = '-1';
+        }
+      });
     },
-    handleBlur() {
-      this.focused = false;
+    onFocusOut(event) {
+      const root = this.$el;
+      const next = event.relatedTarget;
+      if (next && root.contains(next)) {
+        return;
+      }
+      this.tabindex = '0';
+      this.hover = false;
     },
   }
 };

--- a/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationsToolbar.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationsToolbar.vue
@@ -37,14 +37,14 @@
           small
           text
           link
-          @click="openApplications('seeMore')"
-          @focusin="$emit('focus')">
+          @click="openApplications('seeMore')">
           <span class="primary--text text-none">
             {{ $t('myApplications.seeMore.label') }}
           </span>
         </v-btn>
         <v-btn
           v-else
+          ref="btnSeeMoreIcon"
           :loading="loading === 'seeMoreIcon'"
           :title="$t('myApplications.seeMore.tooltip')"
           color="primary"
@@ -52,8 +52,7 @@
           small
           link
           icon
-          @click="openApplications('seeMoreIcon')"
-          @keydown.tab.stop="onShiftTabPress">
+          @click="openApplications('seeMoreIcon')">
           <v-icon
             :size="18"
             class="icon-default-size">
@@ -135,16 +134,6 @@ export default {
           document.dispatchEvent(new CustomEvent('CustomEventOpenApplicationLauncherDrawer'));
         })
         .finally(() => this.loading = null);
-    },
-    onShiftTabPress(event) {
-      if (event.shiftKey) {
-        this.$emit('blur');
-      }
-    },
-    onTabPress(event) {
-      if (event.key === 'Tab' && !event.shiftKey) {
-        this.$emit('blur');
-      }
     }
   },
 };


### PR DESCRIPTION
Prior to this change, in the myApplications portlet, the behavior of the “see all” text must be the same as that of the hover; it must reappear after tabbing out of the portlet, not after leaving the toolbar. This change will improve the portlet so that the text reappears after exiting the portlet using the Tab key.