### PR TITLE
fix: Add titles for some buttons in myApplications portlet - MEED-9936 - Meeds-io/meeds#3832

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationsToolbar.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationsToolbar.vue
@@ -42,73 +42,52 @@
             {{ $t('myApplications.seeMore.label') }}
           </span>
         </v-btn>
-        <v-tooltip
+        <v-btn
           v-else
-          bottom>
-          <template #activator="{ on, attrs }">
-            <v-btn
-              v-bind="attrs"
-              v-on="on"
-              :loading="loading === 'seeMoreIcon'"
-              color="primary"
-              class="ms-2 text-font-size"
-              small
-              link
-              icon
-              @click="openApplications('seeMoreIcon')">
-              <v-icon
-                :size="18"
-                class="icon-default-size">
-                fas fa-external-link-alt
-              </v-icon>
-            </v-btn>
-          </template>
-          {{ $t('myApplications.seeMore.tooltip') }}
-        </v-tooltip>
+          :loading="loading === 'seeMoreIcon'"
+          :title="$t('myApplications.seeMore.tooltip')"
+          color="primary"
+          class="ms-2 text-font-size"
+          small
+          link
+          icon
+          @click="openApplications('seeMoreIcon')">
+          <v-icon
+            :size="18"
+            class="icon-default-size">
+            fas fa-external-link-alt
+          </v-icon>
+        </v-btn>
       </template>
-      <v-tooltip
+      <v-btn
         v-if="hover && isAdmin"
-        bottom>
-        <template #activator="{ on, attrs }">
-          <v-btn
-            v-bind="attrs"
-            v-on="on"
-            class="ms-2 text-font-size"
-            small
-            link
-            icon
-            @click="$emit('open-settings')">
-            <v-icon
-              :size="18"
-              class="icon-default-size icon-default-color">
-              fas fa-cog
-            </v-icon>
-          </v-btn>
-        </template>
-        {{ $t('myApplications.editSettings.tooltip') }}
-      </v-tooltip>
-      <v-tooltip
+        :title="$t('myApplications.editSettings.tooltip')"
+        class="ms-2 text-font-size"
+        small
+        link
+        icon
+        @click="$emit('open-settings')">
+        <v-icon
+          :size="18"
+          class="icon-default-size icon-default-color">
+          fas fa-cog
+        </v-icon>
+      </v-btn>
+      <v-btn
         v-if="!hasApplications"
-        bottom>
-        <template #activator="{ on, attrs }">
-          <v-btn
-            v-bind="attrs"
-            v-on="on"
-            :loading="loading === 'addAppIcon'"
-            class="ms-2 text-font-size"
-            small
-            link
-            icon
-            @click="openApplications('seeMoreIcon')">
-            <v-icon
-              :size="18"
-              class="icon-default-color icon-default-size">
-              fas fa-plus
-            </v-icon>
-          </v-btn>
-        </template>
-        {{ $t('myApplications.add.application.tooltip') }}
-      </v-tooltip>
+        :title="$t('myApplications.add.application.tooltip')"
+        :loading="loading === 'addAppIcon'"
+        class="ms-2 text-font-size"
+        small
+        link
+        icon
+        @click="openApplications('seeMoreIcon')">
+        <v-icon
+          :size="18"
+          class="icon-default-color icon-default-size">
+          fas fa-plus
+        </v-icon>
+      </v-btn>
     </div>
   </div>
 </template>


### PR DESCRIPTION
This change will add titles for "see all", "edit settings" and "add app" buttons in myApplications portlet.

Resolves: Meeds-io/meeds#3832