### PR TITLE
fix: Display the see all buttons when focusing - MEED-9939 - Meeds-io/meeds#3831

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/MyApplicationsApp.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/MyApplicationsApp.vue
@@ -20,12 +20,17 @@
 
 <template>
   <v-app id="myApplications">
-    <v-hover v-slot="{hover}">
+    <v-hover v-model="hover">
       <widget-wrapper
+        ref="widget"
         :loading="isLoading"
-        extra-class="application-body position-static border-box-sizing">
+        :tabindex="tabindex"
+        extra-class="application-body position-static border-box-sizing"
+        @focusin="onFocusIn" 
+        @focusout="onFocusOut">
         <my-applications-toolbar
           v-if="!isLoading"
+          ref="myApplicationsToolbar"
           :hover="hover"
           :is-admin="isAdmin"
           :show-header="showHeader"
@@ -60,6 +65,8 @@ export default {
       alphabeticalOrder: true,
       currentUser: eXo.env.portal.userName,
       initialized: false,
+      hover: false,
+      tabindex: '0'
     };
   },
   computed: {
@@ -187,6 +194,28 @@ export default {
         return;
       }
       this.updateApplicationsOrder(applicationList);
+    },
+    onFocusIn(event) {
+      this.hover =true;
+      this.$nextTick(() => {
+        const activeElement = document.activeElement;
+        const header = this.$refs.myApplicationsToolbar?.$refs?.btnSeeMoreIcon?.$el;
+        if (header && activeElement === this.$refs.widget?.$el && event.relatedTarget) {
+          header.focus();
+        }
+        if (this.tabindex === '0') {
+          this.tabindex = '-1';
+        }
+      });
+    },
+    onFocusOut(event) {
+      const root = this.$el;
+      const next = event.relatedTarget;
+      if (next && root.contains(next)) {
+        return;
+      }
+      this.tabindex = '0';
+      this.hover = false;
     },
   }
 };

--- a/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationsToolbar.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/myApplications/components/view/MyApplicationsToolbar.vue
@@ -44,6 +44,7 @@
         </v-btn>
         <v-btn
           v-else
+          ref="btnSeeMoreIcon"
           :loading="loading === 'seeMoreIcon'"
           :title="$t('myApplications.seeMore.tooltip')"
           color="primary"
@@ -132,7 +133,7 @@ export default {
           document.dispatchEvent(new CustomEvent('CustomEventOpenApplicationLauncherDrawer'));
         })
         .finally(() => this.loading = null);
-    },
+    }
   },
 };
 </script>


### PR DESCRIPTION
Prior to this change, when focusing on "see all" button, the "See all" and "Edit settings" buttons don't appear as per hover. This change will adjust this behavior.

Resolves: Meeds-io/meeds#3831
