### PR TITLE
fix: Prevent encoded characters from appearing in application description - MEED-10020 - Meeds-io/meeds#3890 (#548)

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
@@ -44,7 +44,7 @@
           'light-grey-background-color': !card && hover,
         }
       ]"
-      :title="tooltip ? application.description : ''"
+      :title="tooltip ? applicationDescription : ''"
       :aria-label="ariaLabel"
       class="appLauncherItemContainer fill-height d-flex flex-column align-center justify-center position-relative overflow-hidden border-box-sizing"
       tabindex="0"
@@ -103,7 +103,7 @@
               :class="card && 'align-self-center ps-1' || 'align-self-start'"
               class="d-flex">
               <span :class="card && 'text-title text-start'" class="text-truncate-2">
-                {{ application.title }}
+                {{ applicationTitle }}
               </span>
               <v-icon
                 v-if="application.type === 'LINK' && !application.sameTab"
@@ -144,14 +144,14 @@
           class="d-flex flex-column text-start border-box-sizing"
           flat>
           <div v-if="!card" class="text-truncate white--text">
-            {{ application.title }}
+            {{ applicationTitle }}
           </div>
           <p
             :class="{
               'text-font-small-size white--text': !card,
             }"
             class="text-truncate-3">
-            {{ application.description }}
+            {{ applicationDescription }}
           </p>
           <div 
             class="d-flex align-center mt-auto mb-1 flex-wrap justify-space-between overflow-hidden border-box-sizing"
@@ -325,10 +325,16 @@ export default {
       return this.$t(
         'appCenter.appLauncher.card.ariaLabel',
         [
-          this.application.title,
-          this.application.description,
+          this.applicationTitle,
+          this.applicationDescription,
           shortcut
         ]);
+    },
+    applicationTitle() {
+      return this.application?.title;
+    },
+    applicationDescription() {
+      return this.$utils.htmlToText(this.application?.description);
     }
   },
   methods: {

--- a/app-center-webapps/src/main/webapp/vue-apps/application-setup/components/drawer/ApplicationFormDrawer.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-setup/components/drawer/ApplicationFormDrawer.vue
@@ -496,6 +496,11 @@ export default {
           this.descriptions = this.descriptions || {};
           this.descriptions[eXo.env.portal.defaultLanguage] = app.description || '';
         }
+        this.descriptions = Object.fromEntries(
+          Object.entries(this.descriptions).map(([key, value]) => [
+            key,
+            this.$utils.htmlToText(value)
+          ]));
       } else {
         this.titles = {};
         this.descriptions = {};


### PR DESCRIPTION
Prior to this change, the application description displayed special characters as encoded values. This happened because the description field is saved as a rich translation, which needs to be decoded for display. This change decodes the description when displayed.