### PR TITLE
fix: Help page opening opens app link also - MEED-10136 - Meeds-io/meeds#3988

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
@@ -169,7 +169,7 @@
                 icon
                 mouseup.stop="0"
                 mousedown.stop="0"
-                @click.stop="openHelpPageURL(application.helpPageURL)">
+                @click.stop.prevent="openHelpPageURL(application.helpPageURL)">
                 <v-icon
                   :color="!card && 'white'"
                   :size="card && 20 || 16">


### PR DESCRIPTION
Before this change, when open app center and click on appA help icon, appA link opened along with help page url. To fix this problem, add .prevent to block native navigation. After this change, only the help page URL is opened instead of help page and application link.
