### PR TITLE
fix: Fix card click handling for non-LINK applications - MEED-10141 - Meeds-io/meeds#3993

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
@@ -43,7 +43,9 @@
       @mousedown="onMouseDown"
       @focusin="onFocusIn"
       @focusout="onFocusOut"
-      @click="application.type !== 'LINK' && openApp()">
+      v-on="application.type !== 'LINK' && {
+        click: openApp,
+      }">
       <a
         v-if="application.type === 'LINK' && !readonly"
         :href="computedUrl"


### PR DESCRIPTION
Prior to this change, non-LINK applications were affected by the generic click handling on the v-card component, causing unexpected behavior due to mixed navigation and event handling logic.
This PR fixes the issue by conditionally binding the click event using v-on only for non-LINK application types.
