### PR TITLE
fix: Fix interactive buttons nested inside app card link - MEED-10141 - Meeds-io/meeds#3993

### DIFF
--- a/app-center-webapps/src/main/resources/locale/addon/appcenter_en.properties
+++ b/app-center-webapps/src/main/resources/locale/addon/appcenter_en.properties
@@ -182,3 +182,4 @@ appCenter.userSettings.shortcuts.otherApps=Other Apps
 appCenter.userSettings.shortcuts.editorApps=Editors
 appCenter.userSettings.shortcuts.productShortcutNotEditable=Product shortcut cannot be edited
 appCenter.userSettings.mobile.filterTitle=Filter applications
+appCenter.appLauncher.appLink.ariaLabel=Open application

--- a/app-center-webapps/src/main/resources/locale/addon/appcenter_fr.properties
+++ b/app-center-webapps/src/main/resources/locale/addon/appcenter_fr.properties
@@ -182,3 +182,4 @@ appCenter.userSettings.shortcuts.otherApps=Autres applications
 appCenter.userSettings.shortcuts.editorApps=Éditeurs
 appCenter.userSettings.shortcuts.productShortcutNotEditable=Le raccourci par défaut ne peut pas être modifié
 appCenter.userSettings.mobile.filterTitle=Filtrer les applications
+appCenter.appLauncher.appLink.ariaLabel=Ouvrir l\u2019application

--- a/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
@@ -43,7 +43,9 @@
       @mousedown="onMouseDown"
       @focusin="onFocusIn"
       @focusout="onFocusOut"
-      @click="application.type !== 'LINK' && openApp()">
+      v-on="application.type !== 'LINK' && {
+        click: openApp,
+      }">
       <a
         v-if="application.type === 'LINK' && !readonly"
         :href="computedUrl"

--- a/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
@@ -20,16 +20,6 @@
 <template>
   <v-hover v-model="hover">
     <v-card
-      v-bind="application.type === 'LINK' && !readonly && {
-        href: computedUrl,
-        target: target,
-        rel: 'nofollow noreferrer noopener',
-      }"
-      v-on="application.type === 'LINK' && {
-        click: addToRecent,
-      } || {
-        click: openApp,
-      }"
       :min-width="minWidth"
       :max-width="maxWidth"
       :min-height="minHeight"
@@ -52,7 +42,16 @@
       @keydown.enter="openApp"
       @mousedown="onMouseDown"
       @focusin="onFocusIn"
-      @focusout="onFocusOut">
+      @focusout="onFocusOut"
+      @click="application.type !== 'LINK' && openApp()">
+      <a
+        v-if="application.type === 'LINK' && !readonly"
+        :href="computedUrl"
+        :target="target"
+        :aria-label="$t('appCenter.appLauncher.appLink.ariaLabel')"
+        rel="nofollow noreferrer noopener"
+        class="absolute-full-size z-index-one"
+        @click="addToRecent"></a>
       <div 
         :class="card ? 'absolute-full-size' : 'pt-1'"
         aria-hidden="true">
@@ -160,7 +159,7 @@
               v-if="application.shortcut && !$root.isMobile && hover"
               :shortcut="application.shortcut"
               class="align-self-md-center align-self-end mb-2 mb-md-0 flex-shrink-0 overflow-hidden" />
-            <div class="d-flex align-center justify-end flex-shrink-0 flex-nowrap ms-auto">
+            <div class="d-flex align-center z-index-two justify-end flex-shrink-0 flex-nowrap ms-auto">
               <v-btn
                 v-if="application.helpPageURL"
                 :title="$t('appCenter.appLauncher.accessHelpPageTooltip')"


### PR DESCRIPTION
When an application card was rendered as a link (using v-card with href), all its inner content—including interactive buttons like Help, Pin, and Bookmark—was wrapped inside the anchor element.

This resulted in invalid HTML, since embedding interactive elements inside another interactive element () is prohibited by the HTML standard, and also caused accessibility and UX issues.

This change removes the href/target attributes from v-card and introduces a dedicated overlay anchor element positioned absolutely over the card surface. The overlay handles navigation clicks, while action buttons are kept outside the link and layered above it using z-index.