### PR TITLE
fix: Add some accessibility requirements to the applications - MEED-10185 - Meeds-io/meeds#4021

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-common/components/AppItem.vue
@@ -35,9 +35,9 @@
         }
       ]"
       :title="tooltip ? applicationDescription : ''"
-      :aria-label="ariaLabel"
+      :aria-label="!linkApplication ? ariaLabel : null"
       class="appLauncherItemContainer fill-height d-flex flex-column align-center justify-center position-relative overflow-hidden border-box-sizing"
-      tabindex="0"
+      :tabindex="!linkApplication ? 0 : null"
       @keydown.space.stop="$emit('toogle-pin', !pinnedApplication)"
       @keydown.enter="openApp"
       @mousedown="onMouseDown"
@@ -50,7 +50,7 @@
         v-if="application.type === 'LINK' && !readonly"
         :href="computedUrl"
         :target="target"
-        :aria-label="$t('appCenter.appLauncher.appLink.ariaLabel')"
+        :aria-label="linkApplication ? linkAriaLabel : $t('appCenter.appLauncher.appLink.ariaLabel')"
         rel="nofollow noreferrer noopener"
         class="absolute-full-size z-index-one"
         @click="addToRecent"></a>
@@ -301,6 +301,16 @@ export default {
       } else {
         return null;
       }
+    },
+    linkApplication() {
+      return this.application?.type === 'LINK';
+    },
+    linkAriaLabel() {
+      const shortcut = this.application?.shortcut
+        ? ` & keyboard shortcut: Ctrl + Shift + ${this.application?.shortcut}`
+        : '';
+
+      return `${this.$t('appCenter.appLauncher.appLink.ariaLabel')} : ${this.applicationTitle}, ${this.applicationDescription}${shortcut}`;
     },
     target() {
       return this.application.sameTab ? '_self' : '_blank';


### PR DESCRIPTION
Prior to this change, when accessing the application center in expanded mode and then going to an application using ‘tab’, a double focus occurred on the application card. This was due to the duplicate declaration of the accessible name of the application. To resolve this issue, the tabindex and aria-label attributes are removed from the div tag to avoid double focus (when using the link application), and a detailed and descriptive aria-label attribute is moved to the link so that it's the only focusable element.

Resolves: Meeds-io/meeds#4021