### PR TITLE
fix: show newly added favorite first in the application drawer - MEED-10283 - Meeds-io/meeds#4090

### DIFF
--- a/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterService.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterService.java
@@ -267,6 +267,7 @@ public class ApplicationCenterService {
                                                      application.getTitle()));
     }
     appCenterStorage.addApplicationToUserFavorite(applicationId, username);
+    reorderFavoritesForNewEntry(application.getId(), username);
   }
 
   /**
@@ -583,6 +584,18 @@ public class ApplicationCenterService {
       categoryLinkService = portalContainer.getComponentInstanceOfType(CategoryLinkService.class);
     }
     return categoryLinkService;
+  }
+
+  private void reorderFavoritesForNewEntry(Long applicationId, String username) throws ApplicationNotFoundException {
+    List<UserApplication> userApplication = appCenterStorage.getMandatoryAndFavoriteApplications(username, null)
+                                                            .stream()
+                                                            .filter(app -> app.getOrder() != null)
+                                                            .toList();
+    for (UserApplication application : userApplication) {
+      appCenterStorage.updateFavoriteApplicationOrder(application.getId(),
+                                                      username,
+                                                      application.getId().equals(applicationId) ? 0 : application.getOrder() + 1);
+    }
   }
 
 }


### PR DESCRIPTION
Prior to this change, removing a favorite application and then re-adding it would display it in its old order. This change reorders the user’s favorite applications when adding a new favorite, ensuring that the most recently added application appears first.