### PR TITLE
fix: Fix favorites endpoint to support unpaged results with size=0 - MEED-10293 - Meeds-io/meeds#4112 

### DIFF
--- a/app-center-services/src/main/java/io/meeds/appcenter/rest/ApplicationFavoriteRest.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/rest/ApplicationFavoriteRest.java
@@ -22,17 +22,12 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import io.meeds.appcenter.model.ApplicationList;
@@ -63,7 +58,12 @@ public class ApplicationFavoriteRest {
              description = "Return list of applications in json format")
   @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
                           @ApiResponse(responseCode = "500", description = "Internal server error") })
-  public ApplicationList getFavoriteApplicationsList(HttpServletRequest request, Pageable pageable) {
+  public ApplicationList getFavoriteApplicationsList(HttpServletRequest request,
+                                                     @RequestParam(name = "size", required = false) Integer size,
+                                                     @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    if (size != null && size == 0) {
+      pageable = Pageable.unpaged();
+    }
     return appCenterService.getMandatoryAndFavoriteApplications(pageable, request.getRemoteUser(), request.getLocale());
   }
 


### PR DESCRIPTION
Previously, requests to /favorites with ?size=0 were ignored and the default page size (20) was applied. This meant clients could not fetch all favorite applications in a single request.

This fix adds a check for size=0 in the controller and converts the Pageable to Pageable.unpaged(), allowing the endpoint to return all favorite applications without any pagination limits.
