### PR TITLE
fix: Remove sorting from pageable in favorite applications list -  MEED-10293 - Meeds-io/meeds#4112

### DIFF
--- a/app-center-services/src/main/java/io/meeds/appcenter/rest/ApplicationFavoriteRest.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/rest/ApplicationFavoriteRest.java
@@ -60,7 +60,7 @@ public class ApplicationFavoriteRest {
                           @ApiResponse(responseCode = "500", description = "Internal server error") })
   public ApplicationList getFavoriteApplicationsList(HttpServletRequest request,
                                                      @RequestParam(name = "size", required = false) Integer size,
-                                                     @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+                                                     @PageableDefault(size = 20) Pageable pageable) {
     if (size != null && size == 0) {
       pageable = Pageable.unpaged();
     }


### PR DESCRIPTION
Prior to this change, when the page size is not = 0 then an error is raised in logs:

```
java.lang.IllegalArgumentException: org.hibernate.query.sqm.UnknownPathException: Could not resolve attribute 'createdAt' of 'io.meeds.appcenter.entity.ApplicationEntity' [SELECT new FavoriteApplicationEntity(favoriteApp.id, app, favoriteApp.userName, favoriteApp.order, favoriteApp.favorite) FROM ApplicationEntity app LEFT JOIN FavoriteApplicationEntity favoriteApp ON app.id = favoriteApp.application.id AND favoriteApp.userName = :userName WHERE app.active = TRUE AND (app.isMandatory = TRUE OR (favoriteApp.id IS NOT NULL AND favoriteApp.favorite = TRUE) OR (favoriteApp.id IS NULL AND app.isDefault = TRUE)) ORDER BY favoriteApp.order NULLS LAST, app.order NULLS LAST, app.isMandatory DESC, app.createdAt desc]
```

The field `createdAt` doesn' t exist in JPA Entity `ApplicationEntity` which causes this error. This change will remove the default pageable sort default options to avoid fetching non existant field.