### PR TITLE
fix: support SVG icons for applications - MEED-10330 - Meeds-io/meeds#4045

### DIFF
--- a/app-center-services/src/main/java/io/meeds/appcenter/model/ApplicationForm.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/model/ApplicationForm.java
@@ -33,6 +33,9 @@ public class ApplicationForm extends Application {
   @Exclude
   private String imageUploadId;
 
+  @Exclude
+  private String illustrationMimeType;
+
   public ApplicationForm(Application application) {
     super(application.getId(),
           application.getTitle(),

--- a/app-center-services/src/main/java/io/meeds/appcenter/rest/ApplicationRest.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/rest/ApplicationRest.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.file.services.FileService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.CacheControl;
@@ -69,6 +70,9 @@ public class ApplicationRest {
 
   @Autowired
   private ApplicationCenterService appCenterService;
+
+  @Autowired
+  private FileService fileService;
 
   @GetMapping
   @Secured("users")
@@ -224,6 +228,7 @@ public class ApplicationRest {
       }
     }
     try {
+      String mimeType = fileService.getFileInfo(application.getImageFileId()).getMimetype();
       InputStream stream = appCenterService.getApplicationImageInputStream(applicationId, dimensions);
       if (stream == null) {
         throw new ResponseStatusException(HttpStatus.NOT_FOUND);
@@ -237,7 +242,7 @@ public class ApplicationRest {
       } else {
         builder.cacheControl(CacheControl.noStore());
       }
-      return builder.contentType(MediaType.IMAGE_PNG)
+      return builder.contentType(MediaType.valueOf(mimeType))
                     .body(new InputStreamResource(stream));
     } catch (ApplicationNotFoundException e) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);

--- a/app-center-services/src/main/java/io/meeds/appcenter/storage/ApplicationCenterStorage.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/storage/ApplicationCenterStorage.java
@@ -94,7 +94,7 @@ public class ApplicationCenterStorage {
     applicationEntity.setId(null);
 
     if (application instanceof ApplicationForm applicationForm && StringUtils.isNotBlank(applicationForm.getImageUploadId())) {
-      Long imageFileId = saveImageFileItem(null, applicationForm.getImageUploadId());
+      Long imageFileId = saveImageFileItem(null, applicationForm.getImageUploadId(), applicationForm.getIllustrationMimeType());
       applicationEntity.setImageFileId(imageFileId);
     }
 
@@ -120,7 +120,7 @@ public class ApplicationCenterStorage {
     }
     if (application instanceof ApplicationForm applicationForm
         && StringUtils.isNotBlank(applicationForm.getImageUploadId())) {
-      Long imageFileId = saveImageFileItem(oldImageFileId, applicationForm.getImageUploadId());
+      Long imageFileId = saveImageFileItem(oldImageFileId, applicationForm.getImageUploadId(), applicationForm.getIllustrationMimeType());
       application.setImageFileId(imageFileId);
     }
 
@@ -276,12 +276,12 @@ public class ApplicationCenterStorage {
   }
 
   @SneakyThrows
-  private Long saveImageFileItem(Long imageFileId, String uploadId) {
+  private Long saveImageFileItem(Long imageFileId, String uploadId, String mimeType) {
     UploadResource uploadResource = uploadService.getUploadResource(uploadId);
     byte[] bytesContent = IOUtil.getFileContentAsBytes(uploadResource.getStoreLocation());
     FileItem fileItem = new FileItem(imageFileId,
                                      "appCenterIllustration",
-                                     "image/png",
+                                     mimeType,
                                      NAME_SPACE,
                                      bytesContent.length,
                                      new Date(),

--- a/app-center-services/src/test/java/io/meeds/appcenter/rest/ApplicationRestTest.java
+++ b/app-center-services/src/test/java/io/meeds/appcenter/rest/ApplicationRestTest.java
@@ -28,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.Collections;
 
+import org.exoplatform.commons.file.services.FileService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -94,6 +95,9 @@ public class ApplicationRestTest {
 
   @MockBean
   private ApplicationCenterService applicationCenterService;
+
+  @MockBean
+  private FileService fileService;
 
   @Autowired
   private SecurityFilterChain      filterChain;

--- a/app-center-webapps/src/main/webapp/vue-apps/application-setup/components/drawer/ApplicationFormDrawer.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-setup/components/drawer/ApplicationFormDrawer.vue
@@ -143,7 +143,7 @@
           {{ $t('appCenter.adminSetupForm.updateTheIcon') }}
         </div>
         <app-center-image-input
-          v-model="application.imageUploadId"
+          v-model="uploadedImage"
           :application="application"
           class="mb-4"
           @icon="application.icon = $event"
@@ -330,6 +330,10 @@ export default {
     hasShortcut: false,
     oldCategoryIds: [],
     newCategoryIds: [],
+    uploadedImage: {
+      uploadId: 0,
+      mimeType: ''
+    },
     loading: false
   }),
   computed: {
@@ -420,6 +424,13 @@ export default {
     },
   },
   watch: {
+    uploadedImage: {
+      handler() {
+        this.$set(this.application, 'imageUploadId', this.uploadedImage.uploadId);
+        this.$set(this.application, 'illustrationMimeType', this.uploadedImage.mimeType);
+      },
+      deep: true,
+    },
     type(newVal, oldVal) {
       if (this.drawer && newVal && oldVal && this.application) {
         this.application.url = null;

--- a/app-center-webapps/src/main/webapp/vue-apps/application-setup/components/form/ApplicationImageInput.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-setup/components/form/ApplicationImageInput.vue
@@ -137,7 +137,10 @@ export default {
         return this.$uploadService.upload(file)
           .then(uploadId => {
             if (uploadId) {
-              this.$emit('input', uploadId);
+              this.$emit('input', {
+                uploadId: uploadId,
+                mimeType: file.type
+              });
               const reader = new FileReader();
               reader.onload = (e) => {
                 self.imageData = e.target.result;


### PR DESCRIPTION
Prior to this change, SVG images added as icons to applications were not displayed after saving. This happened because the application illustration URL was hardcoded to use a PNG MIME type, which does not work for vector images like SVG.

Root Cause:
- The uploaded SVG icon was correctly shown in the edit drawer, but after saving, the system reused a hardcoded PNG MIME type for the illustration URL.
- This caused SVG icons to break, since they are not bitmap images.

Fix:
- Store the correct MIME type from FileInfo when uploading the icon.
- Reuse the stored MIME type when generating the illustration URL, ensuring SVG icons are correctly displayed in saved applications.
