### PR TITLE
fix: Set mimetype for application image - MEED-10449 - meeds-io/meeds#4254

### DIFF
--- a/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterInjectService.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/service/ApplicationCenterInjectService.java
@@ -267,6 +267,7 @@ public class ApplicationCenterInjectService {
                                                              UploadResource.UPLOADED_STATUS);
           uploadService.createUploadResource(uploadResource);
           applicationForm.setImageUploadId(uploadId);
+          applicationForm.setIllustrationMimeType("image/png");
         }
       } catch (Exception e) {
         LOG.warn("Error reading image from file {}. Application will be injected without image", imagePath, e);


### PR DESCRIPTION
Before this fix, when an imagePath is used for an application, the image is never displayed due to missing mimetype when the image is stored This commit ensure to set a mimetype in order to have the application displayed

Resolves meeds-io/meeds#4254

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
