### PR TITLE
fix: mark AppCenterMyApplicationsPortlet content as editable - exo-88432

### DIFF
--- a/app-center-webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/app-center-webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -70,6 +70,10 @@
       <name>preload.resource.rest</name>
       <value>/app-center/rest/favorites</value>
     </init-param>
+    <init-param>
+      <name>layout-content-editable</name>
+      <value>true</value>
+    </init-param>
     <expiration-cache>-1</expiration-cache>
     <cache-scope>PUBLIC</cache-scope>
     <supports>


### PR DESCRIPTION
Enables the removal-confirmation dialog in the page builder for the Shortcuts content block, consistent with other admin-editable blocks.