### PR TITLE
feat: Add App-Center MCP tools for EVA (apps, favorites, personal shortcuts) - EXO-88400

### DIFF
--- a/app-center-services/pom.xml
+++ b/app-center-services/pom.xml
@@ -46,6 +46,12 @@
       <groupId>io.meeds.pwa</groupId>
       <artifactId>pwa-service</artifactId>
     </dependency>
+    <!-- MCP Server API -->
+    <dependency>
+      <groupId>io.meeds.mcp-server</groupId>
+      <artifactId>mcp-server-tools</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -61,5 +67,16 @@
   </dependencies>
   <build>
     <finalName>${project.artifactId}</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/app-center-services/src/main/java/io/meeds/appcenter/mcp/AppCenterMcpTool.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/mcp/AppCenterMcpTool.java
@@ -1,0 +1,273 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.appcenter.mcp;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+
+import io.meeds.appcenter.constant.ApplicationType;
+import io.meeds.appcenter.mcp.model.AppModel;
+import io.meeds.appcenter.model.Application;
+import io.meeds.appcenter.model.ApplicationList;
+import io.meeds.appcenter.model.ApplicationOrder;
+import io.meeds.appcenter.model.exception.ApplicationNotFoundException;
+import io.meeds.appcenter.service.ApplicationCenterService;
+import io.meeds.mcp.server.plugin.McpToolPlugin;
+
+/**
+ * MCP tools exposing the App-Center add-on to the AI agent (EVA). Every method
+ * acts as the current user (resolved via {@link #getCurrentUserName()}) and
+ * passes that username to {@link ApplicationCenterService}, so access rights,
+ * favorite ownership and personal-app ownership are all enforced by the
+ * service. Admin-only catalog management is intentionally not exposed here.
+ */
+@Service
+@Profile("mcp-server")
+public class AppCenterMcpTool implements McpToolPlugin {
+
+  private static final int              DEFAULT_LIST_LIMIT = 20;
+
+  private static final int              MAX_LIST_LIMIT     = 100;
+
+  private final ApplicationCenterService applicationCenterService;
+
+  public AppCenterMcpTool(ApplicationCenterService applicationCenterService) {
+    this.applicationCenterService = applicationCenterService;
+  }
+
+  /**
+   * Lists the applications the current user is authorized to use (active apps
+   * they may access), optionally filtered by a keyword on title/url, with each
+   * app flagged as favorite or not.
+   */
+  public List<AppModel> listMyApps(String keyword, Integer offset, Integer limit) {
+    String currentUser = getCurrentUserName();
+    Locale locale = getCurrentUserLocale();
+    ApplicationList list = applicationCenterService.getActiveApplications(clampOffset(offset),
+                                                                          clampLimit(limit),
+                                                                          StringUtils.trimToNull(keyword),
+                                                                          locale,
+                                                                          currentUser);
+    return toModels(list);
+  }
+
+  /**
+   * Lists the current user's launcher drawer: the mandatory apps plus the apps
+   * they marked as favorites.
+   */
+  public List<AppModel> listMyAppDrawer() {
+    String currentUser = getCurrentUserName();
+    Locale locale = getCurrentUserLocale();
+    ApplicationList list = applicationCenterService.getMandatoryAndFavoriteApplications(Pageable.unpaged(),
+                                                                                        currentUser,
+                                                                                        locale);
+    return toModels(list);
+  }
+
+  /**
+   * Adds an application to the current user's favorites.
+   */
+  public String addFavoriteApp(Long applicationId) throws ObjectNotFoundException {
+    long id = requirePositiveId(applicationId);
+    String currentUser = getCurrentUserName();
+    try {
+      applicationCenterService.addFavoriteApplication(id, currentUser);
+    } catch (ApplicationNotFoundException e) {
+      throw notFound(id);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You are not allowed to add application " + id
+          + " to your favorites. Only applications you can access can be favorited.");
+    }
+    return "Application " + id + " has been added to your favorites.";
+  }
+
+  /**
+   * Removes an application from the current user's favorites.
+   */
+  public String removeFavoriteApp(Long applicationId) {
+    long id = requirePositiveId(applicationId);
+    String currentUser = getCurrentUserName();
+    applicationCenterService.deleteFavoriteApplication(id, currentUser);
+    return "Application " + id + " has been removed from your favorites.";
+  }
+
+  /**
+   * Reorders the current user's favorite applications. Pass the favorite
+   * application ids in the desired display order (first id shown first). Any id
+   * that is not yet a favorite gets added while being ordered.
+   */
+  public String reorderFavoriteApps(List<Long> applicationIds) throws ObjectNotFoundException {
+    if (CollectionUtils.isEmpty(applicationIds)) {
+      throw new IllegalArgumentException("application_ids is required: pass the favorite app ids in the desired order.");
+    }
+    String currentUser = getCurrentUserName();
+    long order = 0;
+    for (Long applicationId : applicationIds) {
+      long id = requirePositiveId(applicationId);
+      try {
+        applicationCenterService.updateFavoriteApplicationOrder(new ApplicationOrder(id, order++), currentUser);
+      } catch (ApplicationNotFoundException e) {
+        throw notFound(id);
+      }
+    }
+    return "Reordered " + applicationIds.size() + " favorite application(s).";
+  }
+
+  /**
+   * Creates a personal URL application (a shortcut to an external URL) owned by
+   * the current user. Requires the personal-apps feature to be enabled on the
+   * instance.
+   */
+  public AppModel createPersonalApp(String title, String url, String icon) {
+    if (!applicationCenterService.isUserPersonalAppsEnabled()) {
+      throw new IllegalStateException("Personal apps are disabled on this instance.");
+    }
+    if (StringUtils.isBlank(title)) {
+      throw new IllegalArgumentException("title is required for a personal app.");
+    }
+    if (StringUtils.isBlank(url)) {
+      throw new IllegalArgumentException("url is required for a personal app (the external link it opens).");
+    }
+    String currentUser = getCurrentUserName();
+    Application application = new Application();
+    application.setTitle(title.trim());
+    application.setUrl(url.trim());
+    application.setType(ApplicationType.LINK);
+    if (StringUtils.isNotBlank(icon)) {
+      application.setIcon(icon.trim());
+    }
+    try {
+      Application created = applicationCenterService.createPersonalApplication(application, currentUser);
+      return toModel(created);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You are not allowed to create a personal app: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Updates a personal URL application owned by the current user. Only the
+   * supplied fields are changed (title, url and/or icon).
+   */
+  public AppModel updatePersonalApp(Long applicationId, String title, String url, String icon) throws ObjectNotFoundException {
+    long id = requirePositiveId(applicationId);
+    if (StringUtils.isBlank(title) && StringUtils.isBlank(url) && StringUtils.isBlank(icon)) {
+      throw new IllegalArgumentException("Nothing to update: provide at least one of title, url or icon.");
+    }
+    String currentUser = getCurrentUserName();
+    Application application = applicationCenterService.getApplication(id);
+    if (application == null) {
+      throw notFound(id);
+    }
+    if (StringUtils.isNotBlank(title)) {
+      application.setTitle(title.trim());
+    }
+    if (StringUtils.isNotBlank(url)) {
+      application.setUrl(url.trim());
+    }
+    if (StringUtils.isNotBlank(icon)) {
+      application.setIcon(icon.trim());
+    }
+    try {
+      applicationCenterService.updatePersonalApplication(application, currentUser);
+    } catch (ApplicationNotFoundException e) {
+      throw notFound(id);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You are not allowed to update application " + id
+          + ": it must be a personal app that you own, and the personal-apps feature must be enabled.");
+    }
+    return toModel(applicationCenterService.getApplication(id));
+  }
+
+  /**
+   * Deletes a personal URL application owned by the current user.
+   */
+  public String deletePersonalApp(Long applicationId) throws ObjectNotFoundException {
+    long id = requirePositiveId(applicationId);
+    String currentUser = getCurrentUserName();
+    try {
+      applicationCenterService.deletePersonalApplication(id, currentUser);
+    } catch (ApplicationNotFoundException e) {
+      throw notFound(id);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You are not allowed to delete application " + id
+          + ": it must be a personal app that you own, and the personal-apps feature must be enabled.");
+    }
+    return "Personal application " + id + " has been deleted.";
+  }
+
+  private long requirePositiveId(Long applicationId) {
+    if (applicationId == null || applicationId <= 0) {
+      throw new IllegalArgumentException("application_id is required and must be a positive number.");
+    }
+    return applicationId;
+  }
+
+  private ObjectNotFoundException notFound(long id) {
+    return new ObjectNotFoundException("No application found with id " + id
+        + ". List the current user's apps with list_my_apps to find a valid id.");
+  }
+
+  private int clampOffset(Integer offset) {
+    return (offset == null || offset < 0) ? 0 : offset;
+  }
+
+  private int clampLimit(Integer limit) {
+    if (limit == null || limit <= 0) {
+      return DEFAULT_LIST_LIMIT;
+    }
+    return Math.min(limit, MAX_LIST_LIMIT);
+  }
+
+  private List<AppModel> toModels(ApplicationList list) {
+    List<AppModel> models = new ArrayList<>();
+    if (list != null && CollectionUtils.isNotEmpty(list.getApplications())) {
+      list.getApplications().forEach(application -> models.add(toModel(application)));
+    }
+    return models;
+  }
+
+  private AppModel toModel(Application application) {
+    if (application == null) {
+      return null;
+    }
+    boolean favorite = application.getOrder() != null;
+    if (application instanceof io.meeds.appcenter.model.UserApplication userApplication) {
+      favorite = favorite || userApplication.isFavorite();
+    }
+    return new AppModel(application.getId(),
+                        application.getTitle(),
+                        application.getUrl(),
+                        application.getIcon(),
+                        application.getImageFileId(),
+                        application.getType() == null ? null : application.getType().name(),
+                        favorite,
+                        application.isMandatory(),
+                        application.isPersonal());
+  }
+
+}

--- a/app-center-services/src/main/java/io/meeds/appcenter/mcp/model/AppModel.java
+++ b/app-center-services/src/main/java/io/meeds/appcenter/mcp/model/AppModel.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.appcenter.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A thin representation of an App-Center application returned to the AI agent
+ * (EVA). It exposes only the fields relevant to a user managing their own apps
+ * and never the internal permission/category wiring of the raw entity.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppModel {
+
+  @JsonProperty("app_id")
+  private Long    id;
+
+  private String  title;
+
+  private String  url;
+
+  private String  icon;
+
+  @JsonProperty("image_file_id")
+  private Long    imageFileId;
+
+  /** Application type: LINK, DRAWER or PORTLET. */
+  private String  type;
+
+  /** Whether this app is one of the current user's favorites. */
+  private boolean favorite;
+
+  /** Whether this app is mandatory (always shown, cannot be removed). */
+  private boolean mandatory;
+
+  /** Whether this is a personal URL app created by (and owned by) the user. */
+  private boolean personal;
+
+}

--- a/app-center-services/src/main/resources/ai-tool-definitions.json
+++ b/app-center-services/src/main/resources/ai-tool-definitions.json
@@ -1,0 +1,215 @@
+{
+  "tools": [
+    {
+      "name": "list_my_apps",
+      "title": "List my applications",
+      "description": "List the applications the current user is authorized to use in the Application Center, optionally filtered by a keyword matching the app title or url. Each app is flagged as favorite or not, so you can tell which ones are already in the user's favorites before calling add_favorite_app or remove_favorite_app.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "keyword": {
+            "type": "string",
+            "description": "Optional text to filter apps on their title or url."
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Zero-based index of the first app to return (default 0)."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of apps to return (default 20, max 100)."
+          }
+        }
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "list_my_app_drawer",
+      "title": "List my launcher drawer apps",
+      "description": "List the current user's application launcher drawer: the mandatory applications plus the applications the user marked as favorites. This is what the user sees when opening the apps drawer.",
+      "input_schema": {
+        "type": "object",
+        "properties": {}
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "add_favorite_app",
+      "title": "Add an app to my favorites",
+      "description": "Add an application to the current user's favorites, so it appears in their launcher drawer. Find the application id with list_my_apps. The user can only favorite applications they are allowed to access.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "application_id": {
+            "type": "integer",
+            "description": "Technical id of the application to add to favorites (required). Obtain it from list_my_apps."
+          }
+        },
+        "required": [
+          "application_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "remove_favorite_app",
+      "title": "Remove an app from my favorites",
+      "description": "Remove an application from the current user's favorites. Find the application id with list_my_apps or list_my_app_drawer. Mandatory applications cannot be removed.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "application_id": {
+            "type": "integer",
+            "description": "Technical id of the application to remove from favorites (required)."
+          }
+        },
+        "required": [
+          "application_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "reorder_favorite_apps",
+      "title": "Reorder my favorite apps",
+      "description": "Set the display order of the current user's favorite applications. Pass the favorite application ids in the desired order (the first id is shown first). Any id that is not yet a favorite is added while being ordered. Obtain the ids from list_my_app_drawer.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "application_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "The favorite application ids, in the desired display order (required, first shown first)."
+          }
+        },
+        "required": [
+          "application_ids"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "create_personal_app",
+      "title": "Create a personal app",
+      "description": "Create a personal URL application (a shortcut that opens an external link) owned by the current user, and add it to their favorites. This only works if the personal-apps feature is enabled on the instance; otherwise it fails.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Display name of the personal app (required)."
+          },
+          "url": {
+            "type": "string",
+            "description": "The external URL the app opens (required)."
+          },
+          "icon": {
+            "type": "string",
+            "description": "Optional icon (a CSS icon class name, e.g. an fa/uiIcon class) to display for the app."
+          }
+        },
+        "required": [
+          "title",
+          "url"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "update_personal_app",
+      "title": "Update a personal app",
+      "description": "Update a personal URL application owned by the current user. Only the fields you provide (title, url and/or icon) are changed; the others keep their current value. The user must own the app and the personal-apps feature must be enabled.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "application_id": {
+            "type": "integer",
+            "description": "Technical id of the personal app to update (required)."
+          },
+          "title": {
+            "type": "string",
+            "description": "New display name (optional; leave out to keep the current title)."
+          },
+          "url": {
+            "type": "string",
+            "description": "New external URL (optional; leave out to keep the current url)."
+          },
+          "icon": {
+            "type": "string",
+            "description": "New icon CSS class (optional; leave out to keep the current icon)."
+          }
+        },
+        "required": [
+          "application_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "delete_personal_app",
+      "title": "Delete a personal app",
+      "description": "Delete a personal URL application owned by the current user. Only the owner can delete their personal app, and the personal-apps feature must be enabled.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "application_id": {
+            "type": "integer",
+            "description": "Technical id of the personal app to delete (required)."
+          }
+        },
+        "required": [
+          "application_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    }
+  ]
+}

--- a/app-center-services/src/test/java/io/meeds/appcenter/mcp/AppCenterMcpToolTest.java
+++ b/app-center-services/src/test/java/io/meeds/appcenter/mcp/AppCenterMcpToolTest.java
@@ -1,0 +1,339 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.appcenter.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.services.security.Identity;
+
+import io.meeds.appcenter.constant.ApplicationType;
+import io.meeds.appcenter.mcp.model.AppModel;
+import io.meeds.appcenter.model.Application;
+import io.meeds.appcenter.model.ApplicationList;
+import io.meeds.appcenter.model.ApplicationOrder;
+import io.meeds.appcenter.model.UserApplication;
+import io.meeds.appcenter.model.exception.ApplicationNotFoundException;
+import io.meeds.appcenter.service.ApplicationCenterService;
+
+class AppCenterMcpToolTest {
+
+  private static final String            USERNAME = "testuser1";
+
+  private static final long              APP_ID   = 7L;
+
+  private ApplicationCenterService       applicationCenterService;
+
+  private AppCenterMcpTool               appCenterMcpTool;
+
+  @BeforeEach
+  void setUp() {
+    applicationCenterService = mock(ApplicationCenterService.class);
+    Identity currentIdentity = new Identity(USERNAME);
+    appCenterMcpTool = new AppCenterMcpTool(applicationCenterService) {
+      @Override
+      public Identity getCurrentUserAclIdentity() {
+        return currentIdentity;
+      }
+
+      @Override
+      public Locale getCurrentUserLocale() {
+        return Locale.ENGLISH;
+      }
+    };
+  }
+
+  private Application app(long id, String title, boolean personal) {
+    Application application = new Application();
+    application.setId(id);
+    application.setTitle(title);
+    application.setUrl("https://example.org/" + id);
+    application.setType(ApplicationType.LINK);
+    application.setPersonal(personal);
+    return application;
+  }
+
+  // --- list_my_apps --------------------------------------------------------
+
+  @Test
+  void listMyApps() {
+    UserApplication userApplication = new UserApplication(app(APP_ID, "Wiki", false));
+    userApplication.setFavorite(true);
+    ApplicationList list = new ApplicationList().setApplications(List.of(userApplication)).setSize(1);
+    when(applicationCenterService.getActiveApplications(eq(0), eq(20), isNull(), any(Locale.class), eq(USERNAME)))
+        .thenReturn(list);
+
+    List<AppModel> result = appCenterMcpTool.listMyApps(null, null, null);
+
+    assertNotNull(result);
+    assertEquals(1, result.size());
+    assertEquals(APP_ID, result.get(0).getId());
+    assertTrue(result.get(0).isFavorite());
+    assertEquals("LINK", result.get(0).getType());
+  }
+
+  @Test
+  void listMyAppsWithKeywordAndPaging() {
+    ApplicationList list = new ApplicationList().setApplications(List.of()).setSize(0);
+    when(applicationCenterService.getActiveApplications(eq(5), eq(3), eq("chat"), any(Locale.class), eq(USERNAME)))
+        .thenReturn(list);
+
+    List<AppModel> result = appCenterMcpTool.listMyApps("chat", 5, 3);
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+    verify(applicationCenterService).getActiveApplications(eq(5), eq(3), eq("chat"), any(Locale.class), eq(USERNAME));
+  }
+
+  // --- list_my_app_drawer --------------------------------------------------
+
+  @Test
+  void listMyAppDrawer() {
+    Application mandatory = app(1L, "Home", false);
+    mandatory.setMandatory(true);
+    UserApplication favorite = new UserApplication(app(2L, "Tasks", false));
+    favorite.setFavorite(true);
+    ApplicationList list = new ApplicationList().setApplications(List.of(mandatory, favorite)).setSize(2);
+    when(applicationCenterService.getMandatoryAndFavoriteApplications(any(), eq(USERNAME), any(Locale.class)))
+        .thenReturn(list);
+
+    List<AppModel> result = appCenterMcpTool.listMyAppDrawer();
+
+    assertNotNull(result);
+    assertEquals(2, result.size());
+    assertTrue(result.get(0).isMandatory());
+    assertFalse(result.get(0).isFavorite());
+    assertTrue(result.get(1).isFavorite());
+  }
+
+  // --- add_favorite_app ----------------------------------------------------
+
+  @Test
+  void addFavoriteApp() throws Exception {
+    String message = appCenterMcpTool.addFavoriteApp(APP_ID);
+    assertTrue(message.contains(String.valueOf(APP_ID)));
+    verify(applicationCenterService).addFavoriteApplication(APP_ID, USERNAME);
+  }
+
+  @Test
+  void addFavoriteAppInvalidIdFails() {
+    assertThrows(IllegalArgumentException.class, () -> appCenterMcpTool.addFavoriteApp(null));
+    assertThrows(IllegalArgumentException.class, () -> appCenterMcpTool.addFavoriteApp(0L));
+  }
+
+  @Test
+  void addFavoriteAppUnknownFails() throws Exception {
+    doThrow(new ApplicationNotFoundException("missing")).when(applicationCenterService)
+                                                        .addFavoriteApplication(APP_ID, USERNAME);
+    assertThrows(ObjectNotFoundException.class, () -> appCenterMcpTool.addFavoriteApp(APP_ID));
+  }
+
+  @Test
+  void addFavoriteAppDeniedFails() throws Exception {
+    doThrow(new IllegalAccessException("denied")).when(applicationCenterService)
+                                                 .addFavoriteApplication(APP_ID, USERNAME);
+    assertThrows(IllegalStateException.class, () -> appCenterMcpTool.addFavoriteApp(APP_ID));
+  }
+
+  // --- remove_favorite_app -------------------------------------------------
+
+  @Test
+  void removeFavoriteApp() {
+    String message = appCenterMcpTool.removeFavoriteApp(APP_ID);
+    assertTrue(message.contains(String.valueOf(APP_ID)));
+    verify(applicationCenterService).deleteFavoriteApplication(APP_ID, USERNAME);
+  }
+
+  @Test
+  void removeFavoriteAppInvalidIdFails() {
+    assertThrows(IllegalArgumentException.class, () -> appCenterMcpTool.removeFavoriteApp(null));
+  }
+
+  // --- reorder_favorite_apps -----------------------------------------------
+
+  @Test
+  void reorderFavoriteApps() throws Exception {
+    String message = appCenterMcpTool.reorderFavoriteApps(List.of(3L, 1L, 2L));
+    assertTrue(message.contains("3"));
+    ArgumentCaptor<ApplicationOrder> captor = ArgumentCaptor.forClass(ApplicationOrder.class);
+    verify(applicationCenterService, times(3)).updateFavoriteApplicationOrder(captor.capture(), eq(USERNAME));
+    List<ApplicationOrder> orders = captor.getAllValues();
+    assertEquals(3L, orders.get(0).getId());
+    assertEquals(0L, orders.get(0).getOrder());
+    assertEquals(1L, orders.get(1).getId());
+    assertEquals(1L, orders.get(1).getOrder());
+    assertEquals(2L, orders.get(2).getId());
+    assertEquals(2L, orders.get(2).getOrder());
+  }
+
+  @Test
+  void reorderFavoriteAppsEmptyFails() {
+    assertThrows(IllegalArgumentException.class, () -> appCenterMcpTool.reorderFavoriteApps(List.of()));
+    assertThrows(IllegalArgumentException.class, () -> appCenterMcpTool.reorderFavoriteApps(null));
+  }
+
+  @Test
+  void reorderFavoriteAppsUnknownFails() throws Exception {
+    doThrow(new ApplicationNotFoundException("missing")).when(applicationCenterService)
+                                                        .updateFavoriteApplicationOrder(any(ApplicationOrder.class),
+                                                                                        eq(USERNAME));
+    assertThrows(ObjectNotFoundException.class, () -> appCenterMcpTool.reorderFavoriteApps(List.of(APP_ID)));
+  }
+
+  // --- create_personal_app -------------------------------------------------
+
+  @Test
+  void createPersonalApp() throws Exception {
+    when(applicationCenterService.isUserPersonalAppsEnabled()).thenReturn(true);
+    Application created = app(APP_ID, "My link", true);
+    when(applicationCenterService.createPersonalApplication(any(Application.class), eq(USERNAME))).thenReturn(created);
+
+    AppModel result = appCenterMcpTool.createPersonalApp("My link", "https://example.org/7", "fa-link");
+
+    assertNotNull(result);
+    assertEquals(APP_ID, result.getId());
+    assertTrue(result.isPersonal());
+    ArgumentCaptor<Application> captor = ArgumentCaptor.forClass(Application.class);
+    verify(applicationCenterService).createPersonalApplication(captor.capture(), eq(USERNAME));
+    Application sent = captor.getValue();
+    assertEquals("My link", sent.getTitle());
+    assertEquals("https://example.org/7", sent.getUrl());
+    assertEquals("fa-link", sent.getIcon());
+    assertEquals(ApplicationType.LINK, sent.getType());
+  }
+
+  @Test
+  void createPersonalAppDisabledFails() {
+    when(applicationCenterService.isUserPersonalAppsEnabled()).thenReturn(false);
+    assertThrows(IllegalStateException.class,
+                 () -> appCenterMcpTool.createPersonalApp("My link", "https://example.org", null));
+  }
+
+  @Test
+  void createPersonalAppBlankTitleFails() {
+    when(applicationCenterService.isUserPersonalAppsEnabled()).thenReturn(true);
+    assertThrows(IllegalArgumentException.class,
+                 () -> appCenterMcpTool.createPersonalApp("  ", "https://example.org", null));
+  }
+
+  @Test
+  void createPersonalAppBlankUrlFails() {
+    when(applicationCenterService.isUserPersonalAppsEnabled()).thenReturn(true);
+    assertThrows(IllegalArgumentException.class, () -> appCenterMcpTool.createPersonalApp("Title", " ", null));
+  }
+
+  @Test
+  void createPersonalAppDeniedFails() throws Exception {
+    when(applicationCenterService.isUserPersonalAppsEnabled()).thenReturn(true);
+    when(applicationCenterService.createPersonalApplication(any(Application.class), eq(USERNAME)))
+        .thenThrow(new IllegalAccessException("denied"));
+    assertThrows(IllegalStateException.class,
+                 () -> appCenterMcpTool.createPersonalApp("Title", "https://example.org", null));
+  }
+
+  // --- update_personal_app -------------------------------------------------
+
+  @Test
+  void updatePersonalApp() throws Exception {
+    Application stored = app(APP_ID, "Old", true);
+    when(applicationCenterService.getApplication(APP_ID)).thenReturn(stored);
+
+    AppModel result = appCenterMcpTool.updatePersonalApp(APP_ID, "New title", null, "fa-star");
+
+    assertNotNull(result);
+    ArgumentCaptor<Application> captor = ArgumentCaptor.forClass(Application.class);
+    verify(applicationCenterService).updatePersonalApplication(captor.capture(), eq(USERNAME));
+    Application sent = captor.getValue();
+    assertEquals("New title", sent.getTitle());
+    assertEquals("https://example.org/7", sent.getUrl()); // unchanged
+    assertEquals("fa-star", sent.getIcon());
+  }
+
+  @Test
+  void updatePersonalAppNoFieldsFails() {
+    assertThrows(IllegalArgumentException.class, () -> appCenterMcpTool.updatePersonalApp(APP_ID, null, null, null));
+  }
+
+  @Test
+  void updatePersonalAppUnknownFails() {
+    when(applicationCenterService.getApplication(APP_ID)).thenReturn(null);
+    assertThrows(ObjectNotFoundException.class, () -> appCenterMcpTool.updatePersonalApp(APP_ID, "New", null, null));
+  }
+
+  @Test
+  void updatePersonalAppNotOwnerFails() throws Exception {
+    Application stored = app(APP_ID, "Old", true);
+    when(applicationCenterService.getApplication(APP_ID)).thenReturn(stored);
+    doThrow(new IllegalAccessException("not owner")).when(applicationCenterService)
+                                                    .updatePersonalApplication(any(Application.class), eq(USERNAME));
+    assertThrows(IllegalStateException.class, () -> appCenterMcpTool.updatePersonalApp(APP_ID, "New", null, null));
+  }
+
+  // --- delete_personal_app -------------------------------------------------
+
+  @Test
+  void deletePersonalApp() throws Exception {
+    String message = appCenterMcpTool.deletePersonalApp(APP_ID);
+    assertTrue(message.contains(String.valueOf(APP_ID)));
+    verify(applicationCenterService).deletePersonalApplication(APP_ID, USERNAME);
+  }
+
+  @Test
+  void deletePersonalAppInvalidIdFails() throws Exception {
+    assertThrows(IllegalArgumentException.class, () -> appCenterMcpTool.deletePersonalApp(0L));
+    verify(applicationCenterService, never()).deletePersonalApplication(anyLong(), anyString());
+  }
+
+  @Test
+  void deletePersonalAppUnknownFails() throws Exception {
+    doThrow(new ApplicationNotFoundException("missing")).when(applicationCenterService)
+                                                        .deletePersonalApplication(APP_ID, USERNAME);
+    assertThrows(ObjectNotFoundException.class, () -> appCenterMcpTool.deletePersonalApp(APP_ID));
+  }
+
+  @Test
+  void deletePersonalAppDeniedFails() throws Exception {
+    doThrow(new IllegalAccessException("not owner")).when(applicationCenterService)
+                                                    .deletePersonalApplication(APP_ID, USERNAME);
+    assertThrows(IllegalStateException.class, () -> appCenterMcpTool.deletePersonalApp(APP_ID));
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 		<io.meeds.social.version>7.3.x-SNAPSHOT</io.meeds.social.version>
     <io.meeds.platform-ui.version>7.3.x-SNAPSHOT</io.meeds.platform-ui.version>
     <addon.meeds.pwa.version>7.3.x-SNAPSHOT</addon.meeds.pwa.version>
+    <addon.meeds.mcp-server.version>7.3.x-SNAPSHOT</addon.meeds.mcp-server.version>
 
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>
@@ -70,6 +71,13 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <groupId>io.meeds.pwa</groupId>
         <artifactId>pwa</artifactId>
         <version>${addon.meeds.pwa.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.meeds.mcp-server</groupId>
+        <artifactId>mcp-server</artifactId>
+        <version>${addon.meeds.mcp-server.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## What

Backports #595 (EXO-88400) to `develop`: 8 MCP tools in a new `io.meeds.appcenter.mcp` package (`app-center-services`) letting EVA manage a user's apps, acting **as the current user** — all map to `@Secured("users")` endpoints; the admin catalog CRUD is excluded.

| Tool | R/W | Backing `ApplicationCenterService` |
|------|-----|-------------------------------------|
| `list_my_apps(keyword?, offset?, limit?)` | read | `getActiveApplications` |
| `list_my_app_drawer()` | read | `getMandatoryAndFavoriteApplications` |
| `add_favorite_app(application_id)` | write · approval | `addFavoriteApplication` |
| `remove_favorite_app(application_id)` | write · approval | `deleteFavoriteApplication` |
| `reorder_favorite_apps(application_order)` | write · approval | `updateFavoriteApplicationOrder` |
| `create_personal_app(title, url, icon?)` | write · approval | `createPersonalApplication` (gated on `isUserPersonalAppsEnabled`) |
| `update_personal_app(application_id, …)` | write · approval | `updatePersonalApplication` (fetch-mutate-save) |
| `delete_personal_app(application_id)` | write · approval | `deletePersonalApplication` |

One commit, cherry-picked from `feature/ai-contribution` (`-x` for traceability): #595.

## Conflict resolution

#595 was authored against `feature/ai-contribution`'s versioning scheme (`7.3.x-ai-contribution-SNAPSHOT`). `develop` uses the plain `7.3.x-SNAPSHOT` scheme, so the new `addon.meeds.mcp-server.version` property (and only that new property) was re-pointed to `7.3.x-SNAPSHOT` to match `develop`'s existing 3 properties and the `mcp-server` BOM import convention already used by e.g. `matrix`. No existing property value changed — purely additive, so no other feature's build config is affected.

Its prerequisite, Personal Apps (#594, EXO-88377), is already on `develop` via #599 — including a later storage refactor (settings as a single JSON blob) that landed after #595 was originally authored. Re-verified the MCP tool still works correctly against that refactored service (see Test).

## Test

- `mvn -pl app-center-services -am -Dcheckstyle.skip=true -DskipTests install` → BUILD SUCCESS
- `mvn -pl app-center-services -Dcheckstyle.skip=true -Dtest=AppCenterMcpToolTest,ApplicationCenterServiceTest test` → 48 tests, 0 failures/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)