### PR TITLE
feat: Use and edit personal applications on mobile - EXO-88976

### DIFF
--- a/app-center-webapps/src/main/webapp/vue-apps/application-launcher/components/AppLauncherDrawer.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-launcher/components/AppLauncherDrawer.vue
@@ -166,7 +166,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         ref="mobileDrawer"
         :applications="availableApplications"
         @open="openApplication"
-        @toogle-favorite="toogleFavorite" />
+        @toogle-favorite="toogleFavorite"
+        @edit="editPersonalApp" />
       <app-center-form-drawer
         ref="personalAppFormDrawer"
         personal

--- a/app-center-webapps/src/main/webapp/vue-apps/application-launcher/components/AppLauncherMobileDrawer.vue
+++ b/app-center-webapps/src/main/webapp/vue-apps/application-launcher/components/AppLauncherMobileDrawer.vue
@@ -100,7 +100,8 @@
                 card
                 elevate
                 @open="$emit('open', application.type, application.url)"
-                @toogle-favorite="$emit('toogle-favorite', application)" />
+                @toogle-favorite="$emit('toogle-favorite', application)"
+                @edit="$emit('edit', application)" />
             </div>
           </div>
         </v-layout>


### PR DESCRIPTION
## Why

Personal applications were unusable on mobile:

- A personal application was stored with `IS_MOBILE = false`, so every mobile
  list filtered it out (`app.mobile`): the app launcher favourites, the mobile
  "See all" drawer and the *My applications* widget.
- The mobile "See all" drawer rendered the card actions but relayed none of them,
  so the edit button added by EXO-88964 did nothing there.

## What

- `createPersonalApplication` and `updatePersonalApplication` force
  `isMobile = true`. The personal form has no mobile switch on purpose: a personal
  app is a shortcut the user created for themselves, so it has to be listed
  wherever they are, and the flag is not left to the client.
- `AppLauncherMobileDrawer` relays the `edit` event up to `AppLauncherDrawer`,
  which opens the personal application form drawer with the application. It is
  the same method as the desktop list, so editing and deleting (footer button
  behind its confirmation popup) behave the same on both.

No data upgrade ships with this change: the feature is new, so the personal
applications already created can be deleted and added again, and an application
left as is gets its flag fixed by its first update.

## Tests

- `ApplicationCenterServiceTest`: 23 tests green, with two assertions added — the
  flag is forced on creation whatever the payload says, and an application stored
  before this change is fixed by its first update.
- Validated manually on a local 7.3 instance: the personal application shows up
  in the launcher and in the mobile "See all" drawer, its card opens the prefilled
  edit drawer, update and delete refresh the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
